### PR TITLE
feat: add social media parser package

### DIFF
--- a/.bumpprc.json
+++ b/.bumpprc.json
@@ -1,0 +1,12 @@
+{
+  "files": [
+    "package.json"
+  ],
+  "all": true,
+  "push": true,
+  "tag": true,
+  "commit": "chore: release v%s",
+  "no-verify": true,
+  "release": "patch",
+  "yes": true
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run checks
+        run: bun run check
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Validate tag matches package version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Build
+        run: bun run build
+
+      - name: Setup Node.js for npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Run tests with coverage
+        run: bun run test:coverage
+
+      - name: Build
+        run: bun run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+coverage
+.DS_Store

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,101 @@
+{
+  "rules": {
+    "typescript": "warn",
+    "unicorn": "warn",
+    "import": "warn",
+    "jsdoc": "off",
+    "jsx-a11y": "off",
+    "nextjs": "off",
+    "react": "off",
+    "react-hooks": "off",
+    "typescript/array-type": [
+      "error",
+      {
+        "default": "array"
+      }
+    ],
+    "typescript/adjacent-overload-signatures": "error",
+    "typescript/ban-tslint-comment": "error",
+    "typescript/ban-ts-comment": "warn",
+    "typescript/consistent-indexed-object-style": "error",
+    "typescript/consistent-type-assertions": [
+      "error",
+      {
+        "assertionStyle": "as"
+      }
+    ],
+    "typescript/consistent-type-definitions": [
+      "error",
+      "interface"
+    ],
+    "typescript/no-array-constructor": "error",
+    "typescript/no-confusing-non-null-assertion": "error",
+    "typescript/no-duplicate-enum-values": "error",
+    "typescript/no-empty-function": "error",
+    "typescript/no-empty-interface": "error",
+    "typescript/no-explicit-any": "warn",
+    "typescript/no-extra-non-null-assertion": "error",
+    "typescript/no-inferrable-types": "error",
+    "typescript/no-misused-new": "error",
+    "typescript/no-namespace": "error",
+    "typescript/no-non-null-asserted-optional-chain": "error",
+    "typescript/no-non-null-assertion": "warn",
+    "typescript/no-this-alias": "error",
+    "typescript/no-unnecessary-type-assertion": "error",
+    "typescript/no-unnecessary-type-constraint": "error",
+    "typescript/no-unsafe-declaration-merging": "error",
+    "typescript/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
+    "typescript/no-useless-constructor": "error",
+    "typescript/prefer-as-const": "error",
+    "typescript/prefer-for-of": "error",
+    "typescript/prefer-function-type": "error",
+    "typescript/prefer-namespace-keyword": "error",
+    "typescript/prefer-ts-expect-error": "error",
+    "typescript/triple-slash-reference": "error",
+    "typescript/ban-types": "error",
+    "typescript/consistent-type-imports": [
+      "error",
+      {
+        "prefer": "type-imports",
+        "disallowTypeAnnotations": false
+      }
+    ],
+    "typescript/no-var-requires": "error",
+    "typescript/prefer-includes": "error",
+    "typescript/prefer-string-starts-ends-with": "error",
+    "typescript/prefer-optional-chain": "error",
+    "typescript/prefer-nullish-coalescing": "error",
+    "typescript/no-require-imports": "error",
+    "typescript/no-import-type-side-effects": "error"
+  },
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "globals": {
+    "console": "readonly",
+    "process": "readonly"
+  },
+  "overrides": [
+    {
+      "files": ["test/**/*.ts"],
+      "rules": {
+        "typescript/no-non-null-assertion": "off"
+      }
+    }
+  ],
+  "ignorePatterns": [
+    "node_modules",
+    "dist",
+    "coverage",
+    "*.config.js",
+    "*.config.ts",
+    ".context"
+  ]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,110 @@
+# social-media-parser
+
+Parse, identify, and normalize social media URLs in one step.
+
+## Features
+
+- ⚡ Fast URL parsing and canonical normalization
+- 🌍 Multi-platform support
+- 🧩 Extensible parser architecture
+- 🧼 Cleans tracking params (`utm_*`, `fbclid`, `gclid`, etc.)
+- ✅ Typed API and full test coverage
+
+## Supported Platforms
+
+- 🐦 Twitter / X
+- 📸 Instagram
+- 🎵 TikTok
+- 👽 Reddit
+- 🧑‍💻 GitHub
+- ▶️ YouTube
+- 📘 Facebook
+- 🔎 Search engines (Google, Bing, DuckDuckGo, Yahoo, Yandex, Baidu, Brave, Ecosia, Qwant, Startpage)
+- 💼 LinkedIn
+- 🧵 Threads
+- 🦋 Bluesky
+- 📌 Pinterest
+- 🎮 Twitch
+- ✈️ Telegram
+- 👻 Snapchat
+- 🎬 Vimeo
+- ▶️ Dailymotion
+
+## Installation
+
+```bash
+npm install social-media-parser
+```
+
+## Quick Example
+
+```ts
+import { parse, identify, normalize } from 'social-media-parser'
+
+parse('https://twitter.com/elonmusk/status/1234567890')
+// {
+//   platform: 'twitter',
+//   type: 'post',
+//   entities: { post_id: '1234567890', username: 'elonmusk' },
+//   url: 'https://x.com/i/status/1234567890'
+// }
+
+identify('https://www.instagram.com/johndoe/')
+// 'instagram'
+
+normalize('https://youtu.be/dQw4w9WgXcQ?si=abc&utm_source=test')
+// 'https://youtube.com/watch?v=dQw4w9WgXcQ'
+```
+
+## API
+
+### `parse(input, parsers?)`
+
+Returns:
+
+- `SocialLinkParsedLink` when recognized
+- `null` when input is invalid or unsupported
+
+### `identify(input, parsers?)`
+
+Returns:
+
+- platform string (`'twitter'`, `'instagram'`, etc.)
+- `null` when unsupported
+
+### `normalize(input, parsers?)`
+
+Returns:
+
+- canonical URL string
+- `null` when unsupported
+
+## Custom Parsers
+
+```ts
+import { parse, twitter } from 'social-media-parser'
+
+const result = parse('https://x.com/elonmusk', [twitter])
+```
+
+## Development
+
+- `bun run typecheck`
+- `bun run lint`
+- `bun run lint:fix`
+- `bun run test`
+- `bun run test:coverage`
+- `bun run build`
+- `bun run check`
+- `bun run release`
+- `bun run release:dry-run`
+
+`bun run check` enforces 100% coverage thresholds.
+
+## Release
+
+- Tags: `v*` (example: `v0.1.0`)
+- Workflow: GitHub Actions `Release`
+- Publish command: `npm publish --access public --provenance`
+
+Uses npm provenance (OIDC) and supports `NPM_TOKEN` fallback.

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,334 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "social-media-parser",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.0.18",
+        "bumpp": "^10.4.1",
+        "oxlint": "^1.51.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.51.0", "", { "os": "android", "cpu": "arm" }, "sha512-jJYIqbx4sX+suIxWstc4P7SzhEwb4ArWA2KVrmEuu9vH2i0qM6QIHz/ehmbGE4/2fZbpuMuBzTl7UkfNoqiSgw=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.51.0", "", { "os": "android", "cpu": "arm64" }, "sha512-GtXyBCcH4ti98YdiMNCrpBNGitx87EjEWxevnyhcBK12k/Vu4EzSB45rzSC4fGFUD6sQgeaxItRCEEWeVwPafw=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.51.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3QJbeYaMHn6Bh2XeBXuITSsbnIctyTjvHf5nRjKYrT9pPeErNIpp5VDEeAXC0CZSwSVTsc8WOSDwgrAI24JolQ=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.51.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-NzErhMaTEN1cY0E8C5APy74lw5VwsNfJfVPBMWPVQLqAbO0k4FFLjvHURvkUL+Y18Wu+8Vs1kbqPh2hjXYA4pg=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.51.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-msAIh3vPAoKoHlOE/oe6Q5C/n9umypv/k81lED82ibrJotn+3YG2Qp1kiR8o/Dg5iOEU97c6tl0utxcyFenpFw=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.51.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CqQPcvqYyMe9ZBot2stjGogEzk1z8gGAngIX7srSzrzexmXixwVxBdFZyxTVM0CjGfDeV+Ru0w25/WNjlMM2Hw=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.51.0", "", { "os": "linux", "cpu": "arm" }, "sha512-dstrlYQgZMnyOssxSbolGCge/sDbko12N/35RBNuqLpoPbft2aeBidBAb0dvQlyBd9RJ6u8D4o4Eh8Un6iTgyQ=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.51.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-QEjUpXO7d35rP1/raLGGbAsBLLGZIzV3ZbeSjqWlD3oRnxpRIZ6iL4o51XQHkconn3uKssc+1VKdtHJ81BBhDA=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.51.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-YSJua5irtG4DoMAjUapDTPhkQLHhBIY0G9JqlZS6/SZPzqDkPku/1GdWs0D6h/wyx0Iz31lNCfIaWKBQhzP0wQ=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.51.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-7L4Wj2IEUNDETKssB9IDYt16T6WlF+X2jgC/hBq3diGHda9vJLpAgb09+D3quFq7TdkFtI7hwz/jmuQmQFPc1Q=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.51.0", "", { "os": "linux", "cpu": "none" }, "sha512-cBUHqtOXy76G41lOB401qpFoKx1xq17qYkhWrLSM7eEjiHM9sOtYqpr6ZdqCnN9s6ZpzudX4EkeHOFH2E9q0vA=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.51.0", "", { "os": "linux", "cpu": "none" }, "sha512-WKbg8CysgZcHfZX0ixQFBRSBvFZUHa3SBnEjHY2FVYt2nbNJEjzTxA3ZR5wMU0NOCNKIAFUFvAh5/XJKPRJuJg=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.51.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-N1QRUvJTxqXNSu35YOufdjsAVmKVx5bkrggOWAhTWBc3J4qjcBwr1IfyLh/6YCg8sYRSR1GraldS9jUgJL/U4A=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.51.0", "", { "os": "linux", "cpu": "x64" }, "sha512-e0Mz0DizsCoqNIjeOg6OUKe8JKJWZ5zZlwsd05Bmr51Jo3AOL4UJnPvwKumr4BBtBrDZkCmOLhCvDGm95nJM2g=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.51.0", "", { "os": "linux", "cpu": "x64" }, "sha512-wD8HGTWhYBKXvRDvoBVB1y+fEYV01samhWQSy1Zkxq2vpezvMnjaFKRuiP6tBNITLGuffbNDEXOwcAhJ3gI5Ug=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.51.0", "", { "os": "none", "cpu": "arm64" }, "sha512-5NSwQ2hDEJ0GPXqikjWtwzgAQCsS7P9aLMNenjjKa+gknN3lTCwwwERsT6lKXSirfU3jLjexA2XQvQALh5h27w=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.51.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-JEZyah1M0RHMw8d+jjSSJmSmO8sABA1J1RtrHYujGPeCkYg1NeH0TGuClpe2h5QtioRTaF57y/TZfn/2IFV6fA=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.51.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-q3cEoKH6kwjz/WRyHwSf0nlD2F5Qw536kCXvmlSu+kaShzgrA0ojmh45CA81qL+7udfCaZL2SdKCZlLiGBVFlg=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.51.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Q14+fOGb9T28nWF/0EUsYqERiRA7cl1oy4TJrGmLaqhm+aO2cV+JttboHI3CbdeMCAyDI1+NoSlrM7Melhp/cw=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.0.18", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.0.18", "ast-v8-to-istanbul": "^0.3.10", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.1", "obug": "^2.1.1", "std-env": "^3.10.0", "tinyrainbow": "^3.0.3" }, "peerDependencies": { "@vitest/browser": "4.0.18", "vitest": "4.0.18" }, "optionalPeers": ["@vitest/browser"] }, "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg=="],
+
+    "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
+
+    "@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
+
+    "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
+
+    "args-tokenizer": ["args-tokenizer@0.3.0", "", {}, "sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
+
+    "bumpp": ["bumpp@10.4.1", "", { "dependencies": { "ansis": "^4.2.0", "args-tokenizer": "^0.3.0", "c12": "^3.3.3", "cac": "^6.7.14", "escalade": "^3.2.0", "jsonc-parser": "^3.3.1", "package-manager-detector": "^1.6.0", "semver": "^7.7.3", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "yaml": "^2.8.2" }, "bin": { "bumpp": "bin/bumpp.mjs" } }, "sha512-X/bwWs5Gbb/D7rN4aHLB7zdjiA6nGdjckM1sTHhI9oovIbEw2L5pw5S4xzk8ZTeOZ8EnwU/Ze4SoZ6/Vr3pM2Q=="],
+
+    "c12": ["c12@3.3.3", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^17.2.3", "exsolve": "^1.0.8", "giget": "^2.0.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.0.0", "pkg-types": "^2.3.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
+
+    "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+
+    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
+
+    "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "nypm": ["nypm@0.6.5", "", { "dependencies": { "citty": "^0.2.0", "pathe": "^2.0.3", "tinyexec": "^1.0.2" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ=="],
+
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "oxlint": ["oxlint@1.51.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.51.0", "@oxlint/binding-android-arm64": "1.51.0", "@oxlint/binding-darwin-arm64": "1.51.0", "@oxlint/binding-darwin-x64": "1.51.0", "@oxlint/binding-freebsd-x64": "1.51.0", "@oxlint/binding-linux-arm-gnueabihf": "1.51.0", "@oxlint/binding-linux-arm-musleabihf": "1.51.0", "@oxlint/binding-linux-arm64-gnu": "1.51.0", "@oxlint/binding-linux-arm64-musl": "1.51.0", "@oxlint/binding-linux-ppc64-gnu": "1.51.0", "@oxlint/binding-linux-riscv64-gnu": "1.51.0", "@oxlint/binding-linux-riscv64-musl": "1.51.0", "@oxlint/binding-linux-s390x-gnu": "1.51.0", "@oxlint/binding-linux-x64-gnu": "1.51.0", "@oxlint/binding-linux-x64-musl": "1.51.0", "@oxlint/binding-openharmony-arm64": "1.51.0", "@oxlint/binding-win32-arm64-msvc": "1.51.0", "@oxlint/binding-win32-ia32-msvc": "1.51.0", "@oxlint/binding-win32-x64-msvc": "1.51.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.15.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-g6DNPaV9/WI9MoX2XllafxQuxwY1TV++j7hP8fTJByVBuCoVtm3dy9f/2vtH/HU40JztcgWF4G7ua+gkainklQ=="],
+
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
+
+    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
+
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
+    "vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "nypm/citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "social-media-parser",
+  "version": "0.1.0",
+  "description": "Parse, identify, and normalize social media links across major platforms.",
+  "private": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && bun build src/index.ts --outdir dist --target node && tsc --project tsconfig.build.json",
+    "check": "bun run typecheck && bun run lint && bun run test:coverage",
+    "release": "bun run check && npx bumpp --yes --release patch && git push --follow-tags",
+    "release:dry-run": "bun run check && bun run build && bun run publish:dry-run",
+    "lint": "oxlint src test",
+    "lint:fix": "oxlint src test --fix",
+    "format": "oxlint src test --fix",
+    "prepublishOnly": "bun run check && bun run build",
+    "publish:dry-run": "npm publish --access public --provenance --dry-run",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "social",
+    "social-media",
+    "url",
+    "parser",
+    "normalize",
+    "link-parser",
+    "url-parser",
+    "twitter",
+    "instagram",
+    "tiktok",
+    "reddit",
+    "youtube",
+    "facebook",
+    "linkedin",
+    "threads",
+    "bluesky",
+    "pinterest",
+    "twitch",
+    "telegram",
+    "snapchat",
+    "vimeo",
+    "dailymotion",
+    "typescript"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nikuscs/social-media-parser.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nikuscs/social-media-parser/issues"
+  },
+  "homepage": "https://github.com/nikuscs/social-media-parser#readme",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "bumpp": "^10.4.1",
+    "oxlint": "^1.51.0",
+    "@vitest/coverage-v8": "^4.0.18",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,99 @@
+import type { SocialLinkParsedLink, SocialLinksPlatform, SocialLinksPlatformParser } from './types'
+import { tryParseUrl, cleanUrl } from './url'
+import { twitter } from './parsers/twitter'
+import { instagram } from './parsers/instagram'
+import { tiktok } from './parsers/tiktok'
+import { reddit } from './parsers/reddit'
+import { github } from './parsers/github'
+import { youtube } from './parsers/youtube'
+import { facebook } from './parsers/facebook'
+import { search } from './parsers/search'
+import { linkedin } from './parsers/linkedin'
+import { threads } from './parsers/threads'
+import { bluesky } from './parsers/bluesky'
+import { pinterest } from './parsers/pinterest'
+import { twitch } from './parsers/twitch'
+import { telegram } from './parsers/telegram'
+import { snapchat } from './parsers/snapchat'
+import { vimeo } from './parsers/vimeo'
+import { dailymotion } from './parsers/dailymotion'
+
+export type * from './types'
+export { tryParseUrl, cleanUrl } from './url'
+export { twitter } from './parsers/twitter'
+export { instagram } from './parsers/instagram'
+export { tiktok } from './parsers/tiktok'
+export { reddit } from './parsers/reddit'
+export { github } from './parsers/github'
+export { youtube } from './parsers/youtube'
+export { facebook } from './parsers/facebook'
+export { search } from './parsers/search'
+export { linkedin } from './parsers/linkedin'
+export { threads } from './parsers/threads'
+export { bluesky } from './parsers/bluesky'
+export { pinterest } from './parsers/pinterest'
+export { twitch } from './parsers/twitch'
+export { telegram } from './parsers/telegram'
+export { snapchat } from './parsers/snapchat'
+export { vimeo } from './parsers/vimeo'
+export { dailymotion } from './parsers/dailymotion'
+
+const defaultParsers: SocialLinksPlatformParser[] = [
+  twitter,
+  instagram,
+  tiktok,
+  reddit,
+  github,
+  youtube,
+  facebook,
+  search,
+  linkedin,
+  threads,
+  bluesky,
+  pinterest,
+  twitch,
+  telegram,
+  snapchat,
+  vimeo,
+  dailymotion,
+]
+
+export function parse(
+  input: string,
+  parsers: SocialLinksPlatformParser[] = defaultParsers,
+): SocialLinkParsedLink | null {
+  const url = tryParseUrl(input)
+  if (!url) return null
+
+  const cleaned = cleanUrl(url)
+  const hostname = cleaned.hostname
+
+  for (const parser of parsers) {
+    if (!parser.domains(hostname)) continue
+    const result = parser.parse(cleaned)
+    if (result) {
+      return {
+        platform: parser.platform,
+        type: result.type,
+        entities: result.entities,
+        url: result.url,
+      }
+    }
+  }
+
+  return null
+}
+
+export function identify(
+  input: string,
+  parsers: SocialLinksPlatformParser[] = defaultParsers,
+): SocialLinksPlatform | null {
+  return parse(input, parsers)?.platform ?? null
+}
+
+export function normalize(
+  input: string,
+  parsers: SocialLinksPlatformParser[] = defaultParsers,
+): string | null {
+  return parse(input, parsers)?.url ?? null
+}

--- a/src/parsers/bluesky.ts
+++ b/src/parsers/bluesky.ts
@@ -1,0 +1,36 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+export const bluesky: SocialLinksPlatformParser = {
+  platform: 'bluesky',
+
+  domains(hostname) {
+    return hostname === 'bsky.app' || hostname.endsWith('.bsky.app')
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    if (segments[0] !== 'profile' || !segments[1]) return null
+    const handleOrDid = segments[1]
+
+    // Post: /profile/{did_or_handle}/post/{id}
+    if (segments.length === 4 && segments[2] === 'post' && segments[3]) {
+      return {
+        type: 'post',
+        entities: { handle_or_did: handleOrDid, post_id: segments[3] },
+        url: `https://bsky.app/profile/${handleOrDid}/post/${segments[3]}`,
+      }
+    }
+
+    // Profile: /profile/{did_or_handle}
+    if (segments.length === 2) {
+      return {
+        type: 'profile',
+        entities: { handle_or_did: handleOrDid },
+        url: `https://bsky.app/profile/${handleOrDid}`,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/dailymotion.ts
+++ b/src/parsers/dailymotion.ts
@@ -1,0 +1,46 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+export const dailymotion: SocialLinksPlatformParser = {
+  platform: 'dailymotion',
+
+  domains(hostname) {
+    return (
+      hostname === 'dailymotion.com' ||
+      hostname.endsWith('.dailymotion.com') ||
+      hostname === 'dai.ly'
+    )
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // Short URL: dai.ly/{id}
+    if (url.hostname === 'dai.ly' && segments.length === 1 && segments[0]) {
+      return {
+        type: 'video',
+        entities: { video_id: segments[0] },
+        url: `https://dailymotion.com/video/${segments[0]}`,
+      }
+    }
+
+    // Standard URL: /video/{id}
+    if (segments.length === 2 && segments[0] === 'video' && segments[1]) {
+      return {
+        type: 'video',
+        entities: { video_id: segments[1] },
+        url: `https://dailymotion.com/video/${segments[1]}`,
+      }
+    }
+
+    // Embed URL: /embed/video/{id}
+    if (segments.length === 3 && segments[0] === 'embed' && segments[1] === 'video' && segments[2]) {
+      return {
+        type: 'video',
+        entities: { video_id: segments[2] },
+        url: `https://dailymotion.com/video/${segments[2]}`,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/facebook.ts
+++ b/src/parsers/facebook.ts
@@ -1,0 +1,176 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+const RESERVED = new Set([
+  'marketplace', 'gaming', 'watch', 'groups', 'events', 'pages', 'settings',
+  'help', 'login', 'recover', 'signup', 'policies', 'privacy', 'terms',
+  'ads', 'business', 'creators', 'developers', 'careers', 'about',
+  'fundraisers', 'saved', 'bookmarks', 'notifications', 'messages',
+  'friends', 'memories', 'stories', 'reels', 'feeds', 'search',
+  'hashtag', 'share', 'sharer', 'dialog', 'connect', 'community',
+  'marketplace', 'places', 'offers', 'live', 'directory', 'local',
+  'biz', 'lite', 'flx', 'legal', 'r.php', 'photo', 'video', 'video.php',
+  'permalink.php', 'profile.php', 'photo.php', 'sharer.php', 'story.php',
+])
+
+const USERNAME_RE = /^[a-zA-Z0-9.]{5,50}$/
+
+export const facebook: SocialLinksPlatformParser = {
+  platform: 'facebook',
+
+  domains(hostname) {
+    return (
+      hostname === 'facebook.com' ||
+      hostname.endsWith('.facebook.com') ||
+      hostname === 'fb.com' ||
+      hostname === 'fb.watch'
+    )
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+    const hostname = url.hostname
+
+    // fb.watch/{id} → video
+    if (hostname === 'fb.watch' && segments.length === 1) {
+      return {
+        type: 'video',
+        entities: { video_id: segments[0] },
+        url: `https://facebook.com/watch/?v=${segments[0]}`,
+      }
+    }
+
+    // /profile.php?id={numeric_id}
+    if (segments.length === 1 && segments[0] === 'profile.php') {
+      const id = url.searchParams.get('id')
+      if (id && /^\d+$/.test(id)) {
+        return {
+          type: 'profile',
+          entities: { user_id: id },
+          url: `https://facebook.com/profile.php?id=${id}`,
+        }
+      }
+    }
+
+    // /permalink.php?story_fbid={id}&id={page_id}
+    if (segments.length === 1 && segments[0] === 'permalink.php') {
+      const storyId = url.searchParams.get('story_fbid')
+      const pageId = url.searchParams.get('id')
+      if (storyId) {
+        const entities: Record<string, string> = { post_id: storyId }
+        if (pageId) entities.page_id = pageId
+        return {
+          type: 'post',
+          entities,
+          url: `https://facebook.com/permalink.php?story_fbid=${storyId}`,
+        }
+      }
+    }
+
+    // /photo/?fbid={id} or /photo.php?fbid={id}
+    if (
+      segments.length === 1 &&
+      (segments[0] === 'photo' || segments[0] === 'photo.php')
+    ) {
+      const fbid = url.searchParams.get('fbid')
+      if (fbid) {
+        return {
+          type: 'photo',
+          entities: { photo_id: fbid },
+          url: `https://facebook.com/photo/?fbid=${fbid}`,
+        }
+      }
+    }
+
+    // /watch/?v={id}
+    if (segments.length === 1 && segments[0] === 'watch') {
+      const v = url.searchParams.get('v')
+      if (v) {
+        return {
+          type: 'video',
+          entities: { video_id: v },
+          url: `https://facebook.com/watch/?v=${v}`,
+        }
+      }
+    }
+
+    // /video.php?v={id}
+    if (segments.length === 1 && segments[0] === 'video.php') {
+      const v = url.searchParams.get('v')
+      if (v) {
+        return {
+          type: 'video',
+          entities: { video_id: v },
+          url: `https://facebook.com/video.php?v=${v}`,
+        }
+      }
+    }
+
+    // /reel/{id}
+    if (segments.length === 2 && segments[0] === 'reel') {
+      return {
+        type: 'video',
+        entities: { video_id: segments[1] },
+        url: `https://facebook.com/reel/${segments[1]}`,
+      }
+    }
+
+    // /groups/{name_or_id}
+    if (segments.length === 2 && segments[0] === 'groups') {
+      return {
+        type: 'group',
+        entities: { group_id: segments[1] },
+        url: `https://facebook.com/groups/${segments[1]}`,
+      }
+    }
+
+    // /events/{id}
+    if (segments.length === 2 && segments[0] === 'events') {
+      return {
+        type: 'event',
+        entities: { event_id: segments[1] },
+        url: `https://facebook.com/events/${segments[1]}`,
+      }
+    }
+
+    // /{user}/posts/{post_id}
+    if (segments.length === 3 && segments[1] === 'posts') {
+      return {
+        type: 'post',
+        entities: { post_id: segments[2], username: segments[0] },
+        url: `https://facebook.com/${segments[0]}/posts/${segments[2]}`,
+      }
+    }
+
+    // /{user}/videos/{video_id}
+    if (segments.length === 3 && segments[1] === 'videos') {
+      return {
+        type: 'video',
+        entities: { video_id: segments[2], username: segments[0] },
+        url: `https://facebook.com/${segments[0]}/videos/${segments[2]}`,
+      }
+    }
+
+    // /{user}/photos/{photo_id}
+    if (segments.length === 3 && segments[1] === 'photos') {
+      return {
+        type: 'photo',
+        entities: { photo_id: segments[2], username: segments[0] },
+        url: `https://facebook.com/${segments[0]}/photos/${segments[2]}`,
+      }
+    }
+
+    // Profile: /{username}
+    if (segments.length === 1) {
+      const username = segments[0]
+      if (!RESERVED.has(username.toLowerCase()) && USERNAME_RE.test(username)) {
+        return {
+          type: 'profile',
+          entities: { username },
+          url: `https://facebook.com/${username}`,
+        }
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/github.ts
+++ b/src/parsers/github.ts
@@ -1,0 +1,86 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+const RESERVED = new Set([
+  'issues', 'pulls', 'projects', 'actions', 'settings', 'pulse', 'graphs',
+  'network', 'forks', 'stars', 'watchers', 'wiki', 'security', 'insights',
+  'codespaces', 'packages', 'new', 'import', 'topics', 'collections', 'events',
+  'marketplace', 'explore', 'sponsors', 'orgs', 'organizations', 'users', 'about',
+  'contact', 'pricing', 'site', 'styleguide', 'enterprise', 'features', 'login',
+  'logout', 'join', 'session', 'sessions', 'signup', 'dashboard', 'notifications',
+  'account', 'gist', 'trending', 'search', 'assets', 'images', 'static', 'api', 'raw',
+])
+
+const REPO_SUB_PATHS = new Set([
+  'issues', 'pulls', 'actions', 'projects', 'wiki', 'security', 'insights',
+  'settings', 'releases', 'tags', 'branches', 'commits', 'graphs', 'network',
+  'forks', 'stars', 'watchers', 'pulse',
+])
+
+const GIST_ID_RE = /^[0-9a-fA-F]+$/
+
+export const github: SocialLinksPlatformParser = {
+  platform: 'github',
+
+  domains(hostname) {
+    return hostname === 'github.com' || hostname === 'gist.github.com'
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // Gist: gist.github.com/[{user}/]{hex_id}
+    if (url.hostname === 'gist.github.com') {
+      if (segments.length === 1 && GIST_ID_RE.test(segments[0])) {
+        return {
+          type: 'gist',
+          entities: { gist_id: segments[0] },
+          url: `https://gist.github.com/${segments[0]}`,
+        }
+      }
+      if (segments.length === 2 && GIST_ID_RE.test(segments[1])) {
+        return {
+          type: 'gist',
+          entities: { gist_id: segments[1], username: segments[0] },
+          url: `https://gist.github.com/${segments[1]}`,
+        }
+      }
+      return null
+    }
+
+    // Repository: /{owner}/{repo}
+    if (segments.length >= 2) {
+      const owner = segments[0]
+      const repo = segments[1]
+
+      // Skip if owner is reserved (unless it's orgs/ or sponsors/)
+      if (RESERVED.has(owner.toLowerCase())) {
+        return null
+      }
+
+      // If there's a third segment, it must be a known repo sub-path
+      if (segments.length >= 3 && !REPO_SUB_PATHS.has(segments[2])) {
+        return null
+      }
+
+      return {
+        type: 'repository',
+        entities: { owner, repo },
+        url: `https://github.com/${owner}/${repo}`,
+      }
+    }
+
+    // Profile: /{username}
+    if (segments.length === 1) {
+      const username = segments[0]
+      if (!RESERVED.has(username.toLowerCase())) {
+        return {
+          type: 'profile',
+          entities: { username },
+          url: `https://github.com/${username}`,
+        }
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/instagram.ts
+++ b/src/parsers/instagram.ts
@@ -1,0 +1,68 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+const RESERVED = new Set([
+  'explore', 'accounts', 'direct', 'stories', 'guides', 'saved', 'p', 'reels',
+  'reel', 'tv', 'emailsignup', 'contact', 'legal', 'privacy', 'terms', 'about',
+  'developer', 'blog', 'press', 'api', 'help', 'settings', 'admin', 'login',
+  'logout', 'search', 'directory', 'download', 'shop', 'business', 'creators',
+  'music', 'videos', 'igtv', 'live',
+])
+
+const POST_TYPES = new Set(['p', 'reel', 'reels', 'tv'])
+const USERNAME_RE = /^[a-zA-Z0-9_](?:[a-zA-Z0-9_.]*[a-zA-Z0-9_])?$/
+
+export const instagram: SocialLinksPlatformParser = {
+  platform: 'instagram',
+
+  domains(hostname) {
+    return hostname === 'instagram.com' || hostname.endsWith('.instagram.com')
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // Post: /(p|reel|reels|tv)/{shortcode}
+    if (segments.length === 2 && POST_TYPES.has(segments[0])) {
+      return {
+        type: 'post',
+        entities: { post_id: segments[1] },
+        url: `https://instagram.com/p/${segments[1]}`,
+      }
+    }
+
+    // Post with username prefix: /{user}/(p|reel|reels|tv)/{shortcode}
+    if (segments.length === 3 && POST_TYPES.has(segments[1])) {
+      return {
+        type: 'post',
+        entities: { post_id: segments[2], username: segments[0] },
+        url: `https://instagram.com/p/${segments[2]}`,
+      }
+    }
+
+    // Story: /stories/{username}/{id} (exclude /stories/highlights/)
+    if (segments.length === 3 && segments[0] === 'stories') {
+      if (segments[1] === 'highlights') return null
+      if (/^\d+$/.test(segments[2])) {
+        return {
+          type: 'story',
+          entities: { username: segments[1], story_id: segments[2] },
+          url: `https://instagram.com/stories/${segments[1]}/${segments[2]}`,
+        }
+      }
+    }
+
+    // Profile: /{username}
+    if (segments.length === 1) {
+      const username = segments[0]
+      if (!RESERVED.has(username.toLowerCase()) && USERNAME_RE.test(username)) {
+        return {
+          type: 'profile',
+          entities: { username },
+          url: `https://instagram.com/${username}`,
+        }
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/linkedin.ts
+++ b/src/parsers/linkedin.ts
@@ -1,0 +1,53 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+export const linkedin: SocialLinksPlatformParser = {
+  platform: 'linkedin',
+
+  domains(hostname) {
+    return hostname === 'linkedin.com' || hostname.endsWith('.linkedin.com')
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // Profile: /in/{username}
+    if (segments.length >= 2 && segments[0] === 'in' && segments[1]) {
+      return {
+        type: 'profile',
+        entities: { username: segments[1] },
+        url: `https://linkedin.com/in/${segments[1]}`,
+      }
+    }
+
+    // Company: /company/{company}
+    if (segments.length >= 2 && segments[0] === 'company' && segments[1]) {
+      return {
+        type: 'profile',
+        entities: { company: segments[1] },
+        url: `https://linkedin.com/company/${segments[1]}`,
+      }
+    }
+
+    // Post: /posts/{id}
+    if (segments.length >= 2 && segments[0] === 'posts' && segments[1]) {
+      return {
+        type: 'post',
+        entities: { post_id: segments[1] },
+        url: `https://linkedin.com/posts/${segments[1]}`,
+      }
+    }
+
+    // Post: /feed/update/{urn} or /feed/update?updateEntityUrn={urn}
+    if (segments.length >= 2 && segments[0] === 'feed' && segments[1] === 'update') {
+      const urn = segments[2] ?? url.searchParams.get('updateEntityUrn')
+      if (!urn) return null
+      return {
+        type: 'post',
+        entities: { post_id: urn },
+        url: `https://linkedin.com/feed/update/${urn}`,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/pinterest.ts
+++ b/src/parsers/pinterest.ts
@@ -1,0 +1,61 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+const RESERVED = new Set([
+  'pin',
+  'search',
+  'ideas',
+  'explore',
+  'business',
+  'today',
+  'topics',
+  'settings',
+  'login',
+  'signup',
+  'about',
+  'help',
+])
+
+export const pinterest: SocialLinksPlatformParser = {
+  platform: 'pinterest',
+
+  domains(hostname) {
+    return hostname === 'pinterest.com' || hostname.endsWith('.pinterest.com')
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // Pin: /pin/{id}
+    if (segments.length >= 2 && segments[0] === 'pin' && /^\d+$/.test(segments[1])) {
+      return {
+        type: 'photo',
+        entities: { pin_id: segments[1] },
+        url: `https://pinterest.com/pin/${segments[1]}`,
+      }
+    }
+
+    // Board: /{username}/{board}
+    if (
+      segments.length === 2 &&
+      !RESERVED.has(segments[0].toLowerCase()) &&
+      segments[1]
+    ) {
+      return {
+        type: 'board',
+        entities: { username: segments[0], board: segments[1] },
+        url: `https://pinterest.com/${segments[0]}/${segments[1]}`,
+      }
+    }
+
+    // Profile: /{username}
+    if (segments.length === 1 && !RESERVED.has(segments[0].toLowerCase())) {
+      return {
+        type: 'profile',
+        entities: { username: segments[0] },
+        url: `https://pinterest.com/${segments[0]}`,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/reddit.ts
+++ b/src/parsers/reddit.ts
@@ -1,0 +1,122 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+const SUBREDDIT_RE = /^[a-zA-Z0-9_]{3,21}$/
+const POST_ID_RE = /^[a-zA-Z0-9]{6,10}$/
+const COMMENT_ID_RE = /^[a-zA-Z0-9]{7,10}$/
+const USERNAME_RE = /^[a-zA-Z0-9_-]{3,20}$/
+
+export const reddit: SocialLinksPlatformParser = {
+  platform: 'reddit',
+
+  domains(hostname) {
+    return (
+      hostname === 'reddit.com' ||
+      hostname.endsWith('.reddit.com') ||
+      hostname === 'redd.it' ||
+      hostname === 'i.redd.it' ||
+      hostname === 'v.redd.it'
+    )
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+    const hostname = url.hostname
+
+    // Short post: redd.it/{post_id}
+    if (hostname === 'redd.it' && segments.length === 1 && POST_ID_RE.test(segments[0])) {
+      return {
+        type: 'post',
+        entities: { post_id: segments[0] },
+        url: `https://reddit.com/comments/${segments[0]}`,
+      }
+    }
+
+    // Comment: /r/{sub}/comments/{post_id}/{slug}/{comment_id}
+    if (
+      segments.length >= 6 &&
+      segments[0] === 'r' &&
+      SUBREDDIT_RE.test(segments[1]) &&
+      segments[2] === 'comments' &&
+      POST_ID_RE.test(segments[3]) &&
+      COMMENT_ID_RE.test(segments[5])
+    ) {
+      return {
+        type: 'comment',
+        entities: {
+          subreddit: segments[1],
+          post_id: segments[3],
+          comment_id: segments[5],
+        },
+        url: `https://reddit.com/r/${segments[1]}/comments/${segments[3]}/_/${segments[5]}`,
+      }
+    }
+
+    // Post: /r/{sub}/comments/{id}[/{slug}]
+    if (
+      segments.length >= 4 &&
+      segments[0] === 'r' &&
+      SUBREDDIT_RE.test(segments[1]) &&
+      segments[2] === 'comments' &&
+      POST_ID_RE.test(segments[3])
+    ) {
+      return {
+        type: 'post',
+        entities: { subreddit: segments[1], post_id: segments[3] },
+        url: `https://reddit.com/r/${segments[1]}/comments/${segments[3]}`,
+      }
+    }
+
+    // Post/comment without subreddit: /comments/{id}[/slug][/comment_id]
+    if (segments.length >= 2 && segments[0] === 'comments' && POST_ID_RE.test(segments[1])) {
+      if (segments.length >= 4 && COMMENT_ID_RE.test(segments[3])) {
+        return {
+          type: 'comment',
+          entities: { post_id: segments[1], comment_id: segments[3] },
+          url: `https://reddit.com/comments/${segments[1]}/_/${segments[3]}`,
+        }
+      }
+      if (segments.length === 3 && COMMENT_ID_RE.test(segments[2])) {
+        return {
+          type: 'comment',
+          entities: { post_id: segments[1], comment_id: segments[2] },
+          url: `https://reddit.com/comments/${segments[1]}/_/${segments[2]}`,
+        }
+      }
+      return {
+        type: 'post',
+        entities: { post_id: segments[1] },
+        url: `https://reddit.com/comments/${segments[1]}`,
+      }
+    }
+
+    // Profile: /(user|u)/{name}
+    if (
+      segments.length === 2 &&
+      (segments[0] === 'user' || segments[0] === 'u') &&
+      USERNAME_RE.test(segments[1]) &&
+      !/^-+$/.test(segments[1])
+    ) {
+      return {
+        type: 'profile',
+        entities: { username: segments[1] },
+        url: `https://reddit.com/user/${segments[1]}`,
+      }
+    }
+
+    // Subreddit: /r/{name}
+    if (segments.length === 1 && segments[0] === 'r') return null
+    if (
+      segments.length === 2 &&
+      segments[0] === 'r' &&
+      SUBREDDIT_RE.test(segments[1])
+    ) {
+      return {
+        type: 'subreddit',
+        entities: { subreddit: segments[1] },
+        url: `https://reddit.com/r/${segments[1]}`,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/search.ts
+++ b/src/parsers/search.ts
@@ -1,0 +1,60 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+const SEARCH_DOMAINS = new Set([
+  'google.com', 'bing.com', 'duckduckgo.com', 'yahoo.com', 'yandex.com',
+  'baidu.com', 'brave.com', 'search.brave.com', 'ecosia.org', 'qwant.com',
+  'startpage.com',
+  'google.co.uk', 'google.com.au', 'google.ca', 'google.de', 'google.es',
+  'google.fr', 'google.it', 'google.nl', 'google.pl', 'google.pt', 'google.ro',
+  'google.ru', 'google.se', 'google.co.in', 'google.co.jp', 'google.co.kr',
+  'google.co.id', 'google.co.th', 'google.co.za', 'google.co.br', 'google.co.mx',
+  'google.co.nz', 'google.co.ph',
+])
+
+function isSearchDomain(hostname: string): boolean {
+  if (SEARCH_DOMAINS.has(hostname)) return true
+  for (const domain of SEARCH_DOMAINS) {
+    if (hostname.endsWith('.' + domain)) return true
+  }
+  return false
+}
+
+export const search: SocialLinksPlatformParser = {
+  platform: 'search',
+
+  domains: isSearchDomain,
+
+  parse(url): SocialLinksParseResult {
+    const hostname = url.hostname
+    const isBaidu = hostname === 'baidu.com' || hostname.endsWith('.baidu.com')
+    const isYahoo = hostname === 'yahoo.com' || hostname.endsWith('.yahoo.com')
+    const isYandex = hostname === 'yandex.com' || hostname.endsWith('.yandex.com')
+
+    const params = isBaidu
+      ? ['wd']
+      : isYahoo
+        ? ['p', 'q']
+        : isYandex
+          ? ['text', 'q']
+          : ['q']
+
+    let query: string | null = null
+    for (const param of params) {
+      const value = url.searchParams.get(param)
+      if (value) {
+        query = value
+        break
+      }
+    }
+
+    if (query) {
+      return {
+        type: 'search',
+        entities: { query },
+        url: url.href,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/snapchat.ts
+++ b/src/parsers/snapchat.ts
@@ -1,0 +1,33 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+export const snapchat: SocialLinksPlatformParser = {
+  platform: 'snapchat',
+
+  domains(hostname) {
+    return hostname === 'snapchat.com' || hostname.endsWith('.snapchat.com')
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // Public profile: /add/{username}
+    if (segments.length === 2 && segments[0] === 'add' && segments[1]) {
+      return {
+        type: 'profile',
+        entities: { username: segments[1] },
+        url: `https://snapchat.com/add/${segments[1]}`,
+      }
+    }
+
+    // Spotlight: /spotlight/{id}
+    if (segments.length === 2 && segments[0] === 'spotlight' && segments[1]) {
+      return {
+        type: 'short',
+        entities: { video_id: segments[1] },
+        url: `https://snapchat.com/spotlight/${segments[1]}`,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/telegram.ts
+++ b/src/parsers/telegram.ts
@@ -1,0 +1,61 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+export const telegram: SocialLinksPlatformParser = {
+  platform: 'telegram',
+
+  domains(hostname) {
+    return hostname === 't.me' || hostname === 'telegram.me'
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // Invite: /+{invite_code}
+    if (segments.length === 1 && segments[0].startsWith('+') && segments[0].length > 1) {
+      const inviteCode = segments[0].slice(1)
+      return {
+        type: 'group',
+        entities: { invite_code: inviteCode },
+        url: `https://t.me/+${inviteCode}`,
+      }
+    }
+
+    // Invite: /joinchat/{invite_code}
+    if (segments.length === 2 && segments[0] === 'joinchat' && segments[1]) {
+      return {
+        type: 'group',
+        entities: { invite_code: segments[1] },
+        url: `https://t.me/joinchat/${segments[1]}`,
+      }
+    }
+
+    // Channel preview post: /s/{channel}/{post_id}
+    if (segments.length === 3 && segments[0] === 's' && /^\d+$/.test(segments[2])) {
+      return {
+        type: 'post',
+        entities: { channel: segments[1], post_id: segments[2] },
+        url: `https://t.me/${segments[1]}/${segments[2]}`,
+      }
+    }
+
+    // Channel post: /{channel}/{post_id}
+    if (segments.length === 2 && /^\d+$/.test(segments[1])) {
+      return {
+        type: 'post',
+        entities: { channel: segments[0], post_id: segments[1] },
+        url: `https://t.me/${segments[0]}/${segments[1]}`,
+      }
+    }
+
+    // Channel/profile: /{channel}
+    if (segments.length === 1 && segments[0] && segments[0] !== 's' && segments[0] !== 'joinchat') {
+      return {
+        type: 'profile',
+        entities: { username: segments[0] },
+        url: `https://t.me/${segments[0]}`,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/threads.ts
+++ b/src/parsers/threads.ts
@@ -1,0 +1,37 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+export const threads: SocialLinksPlatformParser = {
+  platform: 'threads',
+
+  domains(hostname) {
+    return hostname === 'threads.net' || hostname.endsWith('.threads.net')
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    if (!segments[0] || !segments[0].startsWith('@')) return null
+    const username = segments[0].slice(1)
+    if (!username) return null
+
+    // Post: /@{username}/post/{id}
+    if (segments.length === 3 && segments[1] === 'post' && segments[2]) {
+      return {
+        type: 'post',
+        entities: { username, post_id: segments[2] },
+        url: `https://threads.net/@${username}/post/${segments[2]}`,
+      }
+    }
+
+    // Profile: /@{username}
+    if (segments.length === 1) {
+      return {
+        type: 'profile',
+        entities: { username },
+        url: `https://threads.net/@${username}`,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/tiktok.ts
+++ b/src/parsers/tiktok.ts
@@ -1,0 +1,76 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+const RESERVED = new Set([
+  'upload', 'messages', 'inbox', 'foryou', 'following', 'friends', 'explore',
+  'live', 'search', 'tag', 'music', 'effect', 'template', 'settings', 'download',
+  'about', 'careers', 'newsroom', 'contact', 'help', 'safety', 'terms', 'privacy',
+  'creator', 'business', 'developer', 'legal', 'support', 'security', 'api',
+  'brand', 'advertise', 'embed', 'share', 'comment', 'video',
+  'en', 'es', 'fr', 'de', 'ja', 'ko', 'ru', 'pt', 'ar', 'id',
+])
+
+const VIDEO_ID_RE = /^\d{18,20}$/
+const USERNAME_RE = /^[a-zA-Z0-9_](?:[a-zA-Z0-9_.]*[a-zA-Z0-9_])?$/
+
+export const tiktok: SocialLinksPlatformParser = {
+  platform: 'tiktok',
+
+  domains(hostname) {
+    return hostname === 'tiktok.com' || hostname.endsWith('.tiktok.com')
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+    const hostname = url.hostname
+
+    // Short redirect variants often carry video IDs in query params.
+    if (hostname === 'vm.tiktok.com' || hostname === 'vt.tiktok.com') {
+      const shortVideoId = url.searchParams.get('share_item_id') ?? url.searchParams.get('item_id')
+      if (shortVideoId && VIDEO_ID_RE.test(shortVideoId)) {
+        return {
+          type: 'video',
+          entities: { video_id: shortVideoId },
+          url: `https://tiktok.com/video/${shortVideoId}`,
+        }
+      }
+    }
+
+    // Video: /@{user}/video/{id}
+    if (
+      segments.length === 3 &&
+      segments[0].startsWith('@') &&
+      segments[1] === 'video' &&
+      VIDEO_ID_RE.test(segments[2])
+    ) {
+      const username = segments[0].slice(1)
+      return {
+        type: 'video',
+        entities: { video_id: segments[2], username },
+        url: `https://tiktok.com/@${username}/video/${segments[2]}`,
+      }
+    }
+
+    // Video: /video/{id}
+    if (segments.length === 2 && segments[0] === 'video' && VIDEO_ID_RE.test(segments[1])) {
+      return {
+        type: 'video',
+        entities: { video_id: segments[1] },
+        url: `https://tiktok.com/video/${segments[1]}`,
+      }
+    }
+
+    // Profile: /@{username}
+    if (segments.length === 1 && segments[0].startsWith('@')) {
+      const username = segments[0].slice(1)
+      if (!RESERVED.has(username.toLowerCase()) && USERNAME_RE.test(username)) {
+        return {
+          type: 'profile',
+          entities: { username },
+          url: `https://tiktok.com/@${username}`,
+        }
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/twitch.ts
+++ b/src/parsers/twitch.ts
@@ -1,0 +1,72 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+const RESERVED = new Set([
+  'directory',
+  'downloads',
+  'jobs',
+  'settings',
+  'turbo',
+  'subscriptions',
+  'wallet',
+  'inventory',
+  'drops',
+  'friends',
+  'messages',
+  'search',
+  'p',
+  'videos',
+])
+
+export const twitch: SocialLinksPlatformParser = {
+  platform: 'twitch',
+
+  domains(hostname) {
+    return (
+      hostname === 'twitch.tv' ||
+      hostname.endsWith('.twitch.tv') ||
+      hostname === 'clips.twitch.tv'
+    )
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // Clip: clips.twitch.tv/{slug}
+    if (url.hostname === 'clips.twitch.tv' && segments.length === 1 && segments[0]) {
+      return {
+        type: 'clip',
+        entities: { clip_id: segments[0] },
+        url: `https://clips.twitch.tv/${segments[0]}`,
+      }
+    }
+
+    // VOD: /videos/{id}
+    if (segments.length === 2 && segments[0] === 'videos' && /^\d+$/.test(segments[1])) {
+      return {
+        type: 'video',
+        entities: { video_id: segments[1] },
+        url: `https://twitch.tv/videos/${segments[1]}`,
+      }
+    }
+
+    // Clip: /{channel}/clip/{slug}
+    if (segments.length === 3 && segments[1] === 'clip' && segments[2]) {
+      return {
+        type: 'clip',
+        entities: { username: segments[0], clip_id: segments[2] },
+        url: `https://twitch.tv/${segments[0]}/clip/${segments[2]}`,
+      }
+    }
+
+    // Channel: /{channel}
+    if (segments.length === 1 && !RESERVED.has(segments[0].toLowerCase())) {
+      return {
+        type: 'profile',
+        entities: { username: segments[0] },
+        url: `https://twitch.tv/${segments[0]}`,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/twitter.ts
+++ b/src/parsers/twitter.ts
@@ -1,0 +1,70 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+const RESERVED = new Set([
+  'status', 'messages', 'grok', 'community-notes', 'settings', 'explore',
+  'notifications', 'search', 'home', 'i', 'hashtag', 'about', 'privacy',
+  'terms', 'help', 'ads', 'login', 'signup', 'logout', 'account', 'support',
+  'jobs', 'developers', 'analytics', 'media', 'safety', 'security', 'legal',
+  'cookies', 'accessibility', 'compose', 'intent', 'share', 'lists', 'topics',
+  'communities', 'premium', 'verified', 'tos',
+])
+
+const USERNAME_RE = /^[a-zA-Z0-9_]{1,15}$/
+
+export const twitter: SocialLinksPlatformParser = {
+  platform: 'twitter',
+
+  domains(hostname) {
+    return (
+      hostname === 'twitter.com' ||
+      hostname === 'x.com' ||
+      hostname.endsWith('.twitter.com') ||
+      hostname.endsWith('.x.com')
+    )
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // Post: /i/status/{id}
+    if (segments.length >= 3 && segments[0] === 'i' && segments[1] === 'status' && /^\d+$/.test(segments[2])) {
+      return {
+        type: 'post',
+        entities: { post_id: segments[2] },
+        url: `https://x.com/i/status/${segments[2]}`,
+      }
+    }
+
+    // Post: /{user}/status/{id} or /i/web/status/{id}
+    if (segments.length >= 3) {
+      if (segments[1] === 'status' && /^\d+$/.test(segments[2])) {
+        return {
+          type: 'post',
+          entities: { post_id: segments[2], username: segments[0] },
+          url: `https://x.com/i/status/${segments[2]}`,
+        }
+      }
+      if (segments[0] === 'i' && segments[1] === 'web' && segments[2] === 'status' && segments[3] && /^\d+$/.test(segments[3])) {
+        return {
+          type: 'post',
+          entities: { post_id: segments[3] },
+          url: `https://x.com/i/status/${segments[3]}`,
+        }
+      }
+    }
+
+    // Profile: /{username}
+    if (segments.length === 1) {
+      const username = segments[0]
+      if (!RESERVED.has(username.toLowerCase()) && USERNAME_RE.test(username)) {
+        return {
+          type: 'profile',
+          entities: { username },
+          url: `https://x.com/${username}`,
+        }
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/vimeo.ts
+++ b/src/parsers/vimeo.ts
@@ -1,0 +1,47 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+export const vimeo: SocialLinksPlatformParser = {
+  platform: 'vimeo',
+
+  domains(hostname) {
+    return hostname === 'vimeo.com' || hostname.endsWith('.vimeo.com')
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // Vimeo player: /video/{id}
+    if (segments.length === 2 && segments[0] === 'video' && /^\d+$/.test(segments[1])) {
+      return {
+        type: 'video',
+        entities: { video_id: segments[1] },
+        url: `https://vimeo.com/${segments[1]}`,
+      }
+    }
+
+    // Channel video: /channels/{channel}/{id}
+    if (
+      segments.length === 3 &&
+      segments[0] === 'channels' &&
+      segments[1] &&
+      /^\d+$/.test(segments[2])
+    ) {
+      return {
+        type: 'video',
+        entities: { channel: segments[1], video_id: segments[2] },
+        url: `https://vimeo.com/${segments[2]}`,
+      }
+    }
+
+    // Vimeo direct: /{id}
+    if (segments.length === 1 && /^\d+$/.test(segments[0])) {
+      return {
+        type: 'video',
+        entities: { video_id: segments[0] },
+        url: `https://vimeo.com/${segments[0]}`,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/parsers/youtube.ts
+++ b/src/parsers/youtube.ts
@@ -1,0 +1,108 @@
+import type { SocialLinksParseResult, SocialLinksPlatformParser } from '../types'
+
+const VIDEO_ID_RE = /^[a-zA-Z0-9_-]{11}$/
+
+export const youtube: SocialLinksPlatformParser = {
+  platform: 'youtube',
+
+  domains(hostname) {
+    return (
+      hostname === 'youtube.com' ||
+      hostname.endsWith('.youtube.com') ||
+      hostname === 'youtu.be' ||
+      hostname === 'youtube-nocookie.com' ||
+      hostname.endsWith('.youtube-nocookie.com')
+    )
+  },
+
+  parse(url): SocialLinksParseResult {
+    const segments = url.pathname.split('/').filter(Boolean)
+
+    // youtu.be/{id} → video
+    if (
+      (url.hostname === 'youtu.be') &&
+      segments.length === 1 &&
+      VIDEO_ID_RE.test(segments[0])
+    ) {
+      return {
+        type: 'video',
+        entities: { video_id: segments[0] },
+        url: `https://youtube.com/watch?v=${segments[0]}`,
+      }
+    }
+
+    // /watch?v={id}
+    if (segments.length === 1 && segments[0] === 'watch') {
+      const v = url.searchParams.get('v')
+      if (v && VIDEO_ID_RE.test(v)) {
+        return {
+          type: 'video',
+          entities: { video_id: v },
+          url: `https://youtube.com/watch?v=${v}`,
+        }
+      }
+    }
+
+    // /embed/{id}
+    if (segments.length === 2 && segments[0] === 'embed' && VIDEO_ID_RE.test(segments[1])) {
+      return {
+        type: 'video',
+        entities: { video_id: segments[1] },
+        url: `https://youtube.com/watch?v=${segments[1]}`,
+      }
+    }
+
+    // /shorts/{id}
+    if (segments.length === 2 && segments[0] === 'shorts' && VIDEO_ID_RE.test(segments[1])) {
+      return {
+        type: 'short',
+        entities: { video_id: segments[1] },
+        url: `https://youtube.com/shorts/${segments[1]}`,
+      }
+    }
+
+    // /playlist?list={id}
+    if (segments.length === 1 && segments[0] === 'playlist') {
+      const list = url.searchParams.get('list')
+      if (list) {
+        return {
+          type: 'playlist',
+          entities: { playlist_id: list },
+          url: `https://youtube.com/playlist?list=${list}`,
+        }
+      }
+    }
+
+    // Channel: /@{handle}
+    if (segments.length === 1 && segments[0].startsWith('@')) {
+      const handle = segments[0].slice(1)
+      if (handle.length > 0) {
+        return {
+          type: 'channel',
+          entities: { username: handle },
+          url: `https://youtube.com/@${handle}`,
+        }
+      }
+    }
+
+    // Channel: /channel/{id}
+    if (segments.length === 2 && segments[0] === 'channel') {
+      return {
+        type: 'channel',
+        entities: { channel_id: segments[1] },
+        url: `https://youtube.com/channel/${segments[1]}`,
+      }
+    }
+
+    // Channel: /c/{name} or /user/{name}
+    if (segments.length === 2 && (segments[0] === 'c' || segments[0] === 'user')) {
+      return {
+        type: 'channel',
+        entities: { username: segments[1] },
+        url: `https://youtube.com/@${segments[1]}`,
+      }
+    }
+
+    return null
+  },
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,56 @@
+export type SocialLinksPlatform =
+  | 'twitter'
+  | 'instagram'
+  | 'tiktok'
+  | 'reddit'
+  | 'github'
+  | 'youtube'
+  | 'facebook'
+  | 'search'
+  | 'linkedin'
+  | 'threads'
+  | 'bluesky'
+  | 'pinterest'
+  | 'twitch'
+  | 'telegram'
+  | 'snapchat'
+  | 'vimeo'
+  | 'dailymotion'
+
+export type SocialLinksContentType =
+  | 'post'
+  | 'profile'
+  | 'video'
+  | 'clip'
+  | 'short'
+  | 'story'
+  | 'comment'
+  | 'subreddit'
+  | 'repository'
+  | 'gist'
+  | 'board'
+  | 'channel'
+  | 'playlist'
+  | 'group'
+  | 'event'
+  | 'photo'
+  | 'search'
+
+export interface SocialLinkParsedLink {
+  platform: SocialLinksPlatform
+  type: SocialLinksContentType
+  entities: Record<string, string>
+  url: string
+}
+
+export type SocialLinksParseResult = {
+  type: SocialLinksContentType
+  entities: Record<string, string>
+  url: string
+} | null
+
+export interface SocialLinksPlatformParser {
+  platform: SocialLinksPlatform
+  domains: (hostname: string) => boolean
+  parse: (url: URL) => SocialLinksParseResult
+}

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,0 +1,45 @@
+const TRACKING_PARAMS = new Set([
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'fbclid',
+  'gclid',
+  'ref',
+  'si',
+  'igshid',
+])
+
+export function tryParseUrl(input: string): URL | null {
+  let trimmed = input.trim()
+  if (!trimmed) return null
+  if (!/^https?:\/\//i.test(trimmed)) {
+    trimmed = 'https://' + trimmed
+  }
+  try {
+    return new URL(trimmed)
+  } catch {
+    return null
+  }
+}
+
+export function cleanUrl(url: URL): URL {
+  const cleaned = new URL(url.href)
+  cleaned.protocol = 'https:'
+  cleaned.hostname = cleaned.hostname.toLowerCase()
+  cleaned.hash = ''
+
+  for (const key of Array.from(cleaned.searchParams.keys())) {
+    if (TRACKING_PARAMS.has(key)) {
+      cleaned.searchParams.delete(key)
+    }
+  }
+
+  // Remove trailing slash from pathname (keep "/" for root)
+  if (cleaned.pathname.length > 1 && cleaned.pathname.endsWith('/')) {
+    cleaned.pathname = cleaned.pathname.replace(/\/+$/, '')
+  }
+
+  return cleaned
+}

--- a/test/bluesky.test.ts
+++ b/test/bluesky.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { bluesky } from '../src/parsers/bluesky'
+
+function parse(urlStr: string) {
+  return bluesky.parse(new URL(urlStr))
+}
+
+describe('bluesky', () => {
+  describe('domains', () => {
+    it('matches bsky.app', () => expect(bluesky.domains('bsky.app')).toBe(true))
+    it('matches subdomains of bsky.app', () => expect(bluesky.domains('staging.bsky.app')).toBe(true))
+    it('rejects unrelated domains', () => expect(bluesky.domains('example.com')).toBe(false))
+  })
+
+  describe('profile', () => {
+    it('parses /profile/{handle}', () => {
+      expect(parse('https://bsky.app/profile/alice.bsky.social')).toEqual({
+        type: 'profile',
+        entities: { handle_or_did: 'alice.bsky.social' },
+        url: 'https://bsky.app/profile/alice.bsky.social',
+      })
+    })
+  })
+
+  describe('post', () => {
+    it('parses /profile/{did}/post/{id}', () => {
+      expect(parse('https://bsky.app/profile/did:plc:abc123/post/3kxy9')).toEqual({
+        type: 'post',
+        entities: { handle_or_did: 'did:plc:abc123', post_id: '3kxy9' },
+        url: 'https://bsky.app/profile/did:plc:abc123/post/3kxy9',
+      })
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for non-profile paths', () => {
+      expect(parse('https://bsky.app/settings')).toBeNull()
+    })
+
+    it('returns null for profile without handle/did', () => {
+      expect(parse('https://bsky.app/profile')).toBeNull()
+    })
+
+    it('returns null for unknown profile sub-paths', () => {
+      expect(parse('https://bsky.app/profile/alice.bsky.social/followers')).toBeNull()
+    })
+  })
+})

--- a/test/dailymotion.test.ts
+++ b/test/dailymotion.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { dailymotion } from '../src/parsers/dailymotion'
+
+function parse(urlStr: string) {
+  return dailymotion.parse(new URL(urlStr))
+}
+
+describe('dailymotion', () => {
+  describe('domains', () => {
+    it('matches dailymotion.com', () => expect(dailymotion.domains('dailymotion.com')).toBe(true))
+    it('matches subdomains of dailymotion.com', () => expect(dailymotion.domains('www.dailymotion.com')).toBe(true))
+    it('matches dai.ly', () => expect(dailymotion.domains('dai.ly')).toBe(true))
+    it('rejects unrelated domains', () => expect(dailymotion.domains('example.com')).toBe(false))
+  })
+
+  describe('video', () => {
+    it('parses dai.ly/{id}', () => {
+      expect(parse('https://dai.ly/x9abcde')).toEqual({
+        type: 'video',
+        entities: { video_id: 'x9abcde' },
+        url: 'https://dailymotion.com/video/x9abcde',
+      })
+    })
+
+    it('parses /video/{id}', () => {
+      expect(parse('https://dailymotion.com/video/x9abcde')).toEqual({
+        type: 'video',
+        entities: { video_id: 'x9abcde' },
+        url: 'https://dailymotion.com/video/x9abcde',
+      })
+    })
+
+    it('parses /embed/video/{id}', () => {
+      expect(parse('https://dailymotion.com/embed/video/x9abcde')).toEqual({
+        type: 'video',
+        entities: { video_id: 'x9abcde' },
+        url: 'https://dailymotion.com/video/x9abcde',
+      })
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for unsupported paths', () => {
+      expect(parse('https://dailymotion.com/playlist/x123')).toBeNull()
+    })
+  })
+})

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { normalize, parse } from '../src/index'
+
+describe('cross-platform reserved-route negatives', () => {
+  const cases: { name: string, url: string }[] = [
+    { name: 'twitter home', url: 'https://x.com/home' },
+    { name: 'instagram reels namespace', url: 'https://instagram.com/reels' },
+    { name: 'tiktok video namespace', url: 'https://tiktok.com/video' },
+    { name: 'reddit incomplete subreddit root', url: 'https://reddit.com/r' },
+    { name: 'github org namespace', url: 'https://github.com/orgs/openai' },
+    { name: 'youtube results page', url: 'https://youtube.com/results?search_query=test' },
+    { name: 'facebook video.php without id', url: 'https://facebook.com/video.php' },
+    { name: 'linkedin feed root', url: 'https://linkedin.com/feed' },
+    { name: 'threads non-profile path', url: 'https://threads.net/about' },
+    { name: 'bluesky non-profile path', url: 'https://bsky.app/settings' },
+    { name: 'pinterest search namespace', url: 'https://pinterest.com/search' },
+    { name: 'twitch videos namespace', url: 'https://twitch.tv/videos' },
+    { name: 'telegram incomplete joinchat', url: 'https://t.me/joinchat' },
+    { name: 'snapchat incomplete add', url: 'https://snapchat.com/add' },
+    { name: 'vimeo channel root without video id', url: 'https://vimeo.com/channels/staffpicks' },
+    { name: 'dailymotion video namespace', url: 'https://dailymotion.com/video' },
+    { name: 'search homepage without query', url: 'https://google.com/search' },
+  ]
+
+  it.each(cases)('returns null for $name', ({ url }) => {
+    expect(parse(url)).toBeNull()
+  })
+})
+
+describe('parse/normalize invariants', () => {
+  const canonicalizableUrls = [
+    'https://twitter.com/elonmusk/status/1234567890',
+    'https://www.instagram.com/johndoe/',
+    'https://www.tiktok.com/@user/video/123456789012345678',
+    'https://www.reddit.com/r/typescript/comments/abc123/sample-post',
+    'https://github.com/facebook/react/issues/1',
+    'https://youtu.be/dQw4w9WgXcQ',
+    'https://facebook.com/watch/?v=123456789',
+    'https://www.google.com/search?q=hello+world',
+    'https://linkedin.com/in/jane-doe',
+    'https://threads.net/@johndoe/post/abc123',
+    'https://bsky.app/profile/alice.bsky.social/post/3kxy9',
+    'https://pinterest.com/johndoe/home-decor',
+    'https://clips.twitch.tv/AmazingClipSlug',
+    'https://t.me/openai/123',
+    'https://snapchat.com/spotlight/abc123',
+    'https://vimeo.com/123456789',
+    'https://dailymotion.com/video/x9abcde',
+  ]
+
+  it.each(canonicalizableUrls)('normalize is idempotent for %s', (url) => {
+    const once = normalize(url)
+    expect(once).not.toBeNull()
+    expect(normalize(once!)).toBe(once)
+  })
+
+  it.each(canonicalizableUrls)('parse(normalize(url)) keeps platform/type for %s', (url) => {
+    const parsed = parse(url)
+    expect(parsed).not.toBeNull()
+
+    const normalized = normalize(url)
+    expect(normalized).not.toBeNull()
+
+    const reparsed = parse(normalized!)
+    expect(reparsed).not.toBeNull()
+    expect(reparsed!.platform).toBe(parsed!.platform)
+    expect(reparsed!.type).toBe(parsed!.type)
+  })
+})

--- a/test/facebook.test.ts
+++ b/test/facebook.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest'
+import { facebook } from '../src/parsers/facebook'
+
+function parse(urlStr: string) {
+  return facebook.parse(new URL(urlStr))
+}
+
+describe('facebook', () => {
+  describe('domains', () => {
+    it('matches facebook.com', () => expect(facebook.domains('facebook.com')).toBe(true))
+    it('matches www.facebook.com', () => expect(facebook.domains('www.facebook.com')).toBe(true))
+    it('matches m.facebook.com', () => expect(facebook.domains('m.facebook.com')).toBe(true))
+    it('matches web.facebook.com', () => expect(facebook.domains('web.facebook.com')).toBe(true))
+    it('matches fb.com', () => expect(facebook.domains('fb.com')).toBe(true))
+    it('matches fb.watch', () => expect(facebook.domains('fb.watch')).toBe(true))
+    it('rejects unrelated domains', () => expect(facebook.domains('notfacebook.com')).toBe(false))
+    it('rejects partial match', () => expect(facebook.domains('fakefb.com')).toBe(false))
+  })
+
+  describe('video', () => {
+    it('parses fb.watch/{id}', () => {
+      expect(parse('https://fb.watch/abc123')).toEqual({
+        type: 'video',
+        entities: { video_id: 'abc123' },
+        url: 'https://facebook.com/watch/?v=abc123',
+      })
+    })
+
+    it('parses /watch/?v={id}', () => {
+      expect(parse('https://facebook.com/watch/?v=123456789')).toEqual({
+        type: 'video',
+        entities: { video_id: '123456789' },
+        url: 'https://facebook.com/watch/?v=123456789',
+      })
+    })
+
+    it('parses /video.php?v={id}', () => {
+      expect(parse('https://facebook.com/video.php?v=123456789')).toEqual({
+        type: 'video',
+        entities: { video_id: '123456789' },
+        url: 'https://facebook.com/video.php?v=123456789',
+      })
+    })
+
+    it('parses /reel/{id}', () => {
+      expect(parse('https://facebook.com/reel/123456789')).toEqual({
+        type: 'video',
+        entities: { video_id: '123456789' },
+        url: 'https://facebook.com/reel/123456789',
+      })
+    })
+
+    it('parses /{user}/videos/{id}', () => {
+      expect(parse('https://facebook.com/johndoe/videos/123456')).toEqual({
+        type: 'video',
+        entities: { video_id: '123456', username: 'johndoe' },
+        url: 'https://facebook.com/johndoe/videos/123456',
+      })
+    })
+
+    it('returns null for /watch without v param', () => {
+      expect(parse('https://facebook.com/watch')).toBeNull()
+    })
+  })
+
+  describe('post', () => {
+    it('parses /{user}/posts/{post_id}', () => {
+      expect(parse('https://facebook.com/johndoe/posts/123456789')).toEqual({
+        type: 'post',
+        entities: { post_id: '123456789', username: 'johndoe' },
+        url: 'https://facebook.com/johndoe/posts/123456789',
+      })
+    })
+
+    it('parses /permalink.php?story_fbid={id}&id={page_id}', () => {
+      expect(parse('https://facebook.com/permalink.php?story_fbid=abc123&id=page456')).toEqual({
+        type: 'post',
+        entities: { post_id: 'abc123', page_id: 'page456' },
+        url: 'https://facebook.com/permalink.php?story_fbid=abc123',
+      })
+    })
+
+    it('parses /permalink.php?story_fbid={id} without page id', () => {
+      expect(parse('https://facebook.com/permalink.php?story_fbid=abc123')).toEqual({
+        type: 'post',
+        entities: { post_id: 'abc123' },
+        url: 'https://facebook.com/permalink.php?story_fbid=abc123',
+      })
+    })
+
+    it('returns null for /permalink.php without story_fbid', () => {
+      expect(parse('https://facebook.com/permalink.php?id=123')).toBeNull()
+    })
+  })
+
+  describe('photo', () => {
+    it('parses /photo/?fbid={id}', () => {
+      expect(parse('https://facebook.com/photo/?fbid=123456')).toEqual({
+        type: 'photo',
+        entities: { photo_id: '123456' },
+        url: 'https://facebook.com/photo/?fbid=123456',
+      })
+    })
+
+    it('parses /photo.php?fbid={id}', () => {
+      expect(parse('https://facebook.com/photo.php?fbid=789')).toEqual({
+        type: 'photo',
+        entities: { photo_id: '789' },
+        url: 'https://facebook.com/photo/?fbid=789',
+      })
+    })
+
+    it('parses /{user}/photos/{id}', () => {
+      expect(parse('https://facebook.com/johndoe/photos/123456')).toEqual({
+        type: 'photo',
+        entities: { photo_id: '123456', username: 'johndoe' },
+        url: 'https://facebook.com/johndoe/photos/123456',
+      })
+    })
+
+    it('returns null for /photo without fbid', () => {
+      expect(parse('https://facebook.com/photo')).toBeNull()
+    })
+
+    it('returns null for /photo.php without fbid', () => {
+      expect(parse('https://facebook.com/photo.php')).toBeNull()
+    })
+  })
+
+  describe('profile', () => {
+    it('parses /{username}', () => {
+      expect(parse('https://facebook.com/johndoe')).toEqual({
+        type: 'profile',
+        entities: { username: 'johndoe' },
+        url: 'https://facebook.com/johndoe',
+      })
+    })
+
+    it('parses /profile.php?id={numeric_id}', () => {
+      expect(parse('https://facebook.com/profile.php?id=100000123456789')).toEqual({
+        type: 'profile',
+        entities: { user_id: '100000123456789' },
+        url: 'https://facebook.com/profile.php?id=100000123456789',
+      })
+    })
+
+    it('allows dots in username', () => {
+      const result = parse('https://facebook.com/john.doe')
+      expect(result).not.toBeNull()
+      expect(result!.entities.username).toBe('john.doe')
+    })
+
+    it('rejects usernames shorter than 5 chars', () => {
+      expect(parse('https://facebook.com/abcd')).toBeNull()
+    })
+
+    it('rejects /profile.php with non-numeric id', () => {
+      expect(parse('https://facebook.com/profile.php?id=abc')).toBeNull()
+    })
+
+    it('rejects /profile.php without id', () => {
+      expect(parse('https://facebook.com/profile.php')).toBeNull()
+    })
+
+    it('rejects reserved paths', () => {
+      expect(parse('https://facebook.com/marketplace')).toBeNull()
+      expect(parse('https://facebook.com/settings')).toBeNull()
+      expect(parse('https://facebook.com/watch')).toBeNull()
+      expect(parse('https://facebook.com/groups')).toBeNull()
+      expect(parse('https://facebook.com/events')).toBeNull()
+      expect(parse('https://facebook.com/login')).toBeNull()
+      expect(parse('https://facebook.com/video.php')).toBeNull()
+    })
+  })
+
+  describe('group', () => {
+    it('parses /groups/{name_or_id}', () => {
+      expect(parse('https://facebook.com/groups/typescript.developers')).toEqual({
+        type: 'group',
+        entities: { group_id: 'typescript.developers' },
+        url: 'https://facebook.com/groups/typescript.developers',
+      })
+    })
+  })
+
+  describe('event', () => {
+    it('parses /events/{id}', () => {
+      expect(parse('https://facebook.com/events/123456789')).toEqual({
+        type: 'event',
+        entities: { event_id: '123456789' },
+        url: 'https://facebook.com/events/123456789',
+      })
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for root path', () => {
+      expect(parse('https://facebook.com/')).toBeNull()
+    })
+
+    it('returns null for unrecognized multi-segment paths', () => {
+      expect(parse('https://facebook.com/user/something/else/extra')).toBeNull()
+    })
+
+    it('returns null for fb.watch with extra segments', () => {
+      expect(parse('https://fb.watch/abc/def')).toBeNull()
+    })
+
+    it('does not misidentify a post as a profile', () => {
+      const result = parse('https://facebook.com/johndoe/posts/123456')
+      expect(result!.type).toBe('post')
+    })
+  })
+})

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { github } from '../src/parsers/github'
+
+function parse(urlStr: string) {
+  return github.parse(new URL(urlStr))
+}
+
+describe('github', () => {
+  describe('domains', () => {
+    it('matches github.com', () => expect(github.domains('github.com')).toBe(true))
+    it('matches gist.github.com', () => expect(github.domains('gist.github.com')).toBe(true))
+    it('rejects subdomains', () => expect(github.domains('www.github.com')).toBe(false))
+    it('rejects unrelated domains', () => expect(github.domains('notgithub.com')).toBe(false))
+  })
+
+  describe('gist', () => {
+    it('parses gist.github.com/{hex_id}', () => {
+      expect(parse('https://gist.github.com/abc123def')).toEqual({
+        type: 'gist',
+        entities: { gist_id: 'abc123def' },
+        url: 'https://gist.github.com/abc123def',
+      })
+    })
+
+    it('parses gist.github.com/{user}/{hex_id}', () => {
+      expect(parse('https://gist.github.com/johndoe/abc123def')).toEqual({
+        type: 'gist',
+        entities: { gist_id: 'abc123def', username: 'johndoe' },
+        url: 'https://gist.github.com/abc123def',
+      })
+    })
+
+    it('rejects non-hex gist IDs', () => {
+      expect(parse('https://gist.github.com/xyz-not-hex')).toBeNull()
+    })
+
+    it('rejects non-hex second segment', () => {
+      expect(parse('https://gist.github.com/user/xyz-not-hex')).toBeNull()
+    })
+
+    it('returns null for gist root', () => {
+      expect(parse('https://gist.github.com/')).toBeNull()
+    })
+
+    it('returns null for gist with too many segments', () => {
+      expect(parse('https://gist.github.com/user/abc123/extra')).toBeNull()
+    })
+  })
+
+  describe('repository', () => {
+    it('parses /{owner}/{repo}', () => {
+      expect(parse('https://github.com/facebook/react')).toEqual({
+        type: 'repository',
+        entities: { owner: 'facebook', repo: 'react' },
+        url: 'https://github.com/facebook/react',
+      })
+    })
+
+    it('allows repo sub-paths like /issues', () => {
+      expect(parse('https://github.com/facebook/react/issues')).toEqual({
+        type: 'repository',
+        entities: { owner: 'facebook', repo: 'react' },
+        url: 'https://github.com/facebook/react',
+      })
+    })
+
+    it('rejects unknown third segment', () => {
+      expect(parse('https://github.com/facebook/react/unknown-path')).toBeNull()
+    })
+
+    it('rejects reserved owner paths', () => {
+      expect(parse('https://github.com/explore/something')).toBeNull()
+      expect(parse('https://github.com/settings/tokens')).toBeNull()
+      expect(parse('https://github.com/login/oauth')).toBeNull()
+    })
+  })
+
+  describe('profile', () => {
+    it('parses /{username}', () => {
+      expect(parse('https://github.com/torvalds')).toEqual({
+        type: 'profile',
+        entities: { username: 'torvalds' },
+        url: 'https://github.com/torvalds',
+      })
+    })
+
+    it('rejects reserved paths as profiles', () => {
+      expect(parse('https://github.com/explore')).toBeNull()
+      expect(parse('https://github.com/settings')).toBeNull()
+      expect(parse('https://github.com/login')).toBeNull()
+      expect(parse('https://github.com/trending')).toBeNull()
+      expect(parse('https://github.com/search')).toBeNull()
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for root path', () => {
+      expect(parse('https://github.com/')).toBeNull()
+    })
+  })
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest'
+import { parse, identify, normalize } from '../src/index'
+
+describe('parse', () => {
+  it('parses a Twitter post URL', () => {
+    const result = parse('https://twitter.com/elonmusk/status/1234567890')
+    expect(result).toEqual({
+      platform: 'twitter',
+      type: 'post',
+      entities: { post_id: '1234567890', username: 'elonmusk' },
+      url: 'https://x.com/i/status/1234567890',
+    })
+  })
+
+  it('parses an Instagram profile URL', () => {
+    const result = parse('https://www.instagram.com/johndoe/')
+    expect(result).toEqual({
+      platform: 'instagram',
+      type: 'profile',
+      entities: { username: 'johndoe' },
+      url: 'https://instagram.com/johndoe',
+    })
+  })
+
+  it('parses a TikTok video URL', () => {
+    const result = parse('https://www.tiktok.com/@user/video/123456789012345678')
+    expect(result).toEqual({
+      platform: 'tiktok',
+      type: 'video',
+      entities: { video_id: '123456789012345678', username: 'user' },
+      url: 'https://tiktok.com/@user/video/123456789012345678',
+    })
+  })
+
+  it('parses a Reddit subreddit URL', () => {
+    const result = parse('https://www.reddit.com/r/typescript')
+    expect(result).toEqual({
+      platform: 'reddit',
+      type: 'subreddit',
+      entities: { subreddit: 'typescript' },
+      url: 'https://reddit.com/r/typescript',
+    })
+  })
+
+  it('parses a GitHub repository URL', () => {
+    const result = parse('https://github.com/facebook/react')
+    expect(result).toEqual({
+      platform: 'github',
+      type: 'repository',
+      entities: { owner: 'facebook', repo: 'react' },
+      url: 'https://github.com/facebook/react',
+    })
+  })
+
+  it('parses a YouTube video URL', () => {
+    const result = parse('https://youtu.be/dQw4w9WgXcQ')
+    expect(result).toEqual({
+      platform: 'youtube',
+      type: 'video',
+      entities: { video_id: 'dQw4w9WgXcQ' },
+      url: 'https://youtube.com/watch?v=dQw4w9WgXcQ',
+    })
+  })
+
+  it('parses a Facebook post URL', () => {
+    const result = parse('https://www.facebook.com/johndoe/posts/123456789')
+    expect(result).toEqual({
+      platform: 'facebook',
+      type: 'post',
+      entities: { post_id: '123456789', username: 'johndoe' },
+      url: 'https://facebook.com/johndoe/posts/123456789',
+    })
+  })
+
+  it('parses a Facebook video via fb.watch', () => {
+    const result = parse('https://fb.watch/abc123')
+    expect(result).toEqual({
+      platform: 'facebook',
+      type: 'video',
+      entities: { video_id: 'abc123' },
+      url: 'https://facebook.com/watch/?v=abc123',
+    })
+  })
+
+  it('parses a Google search URL', () => {
+    const result = parse('https://www.google.com/search?q=hello+world')
+    expect(result).toEqual({
+      platform: 'search',
+      type: 'search',
+      entities: { query: 'hello world' },
+      url: 'https://www.google.com/search?q=hello+world',
+    })
+  })
+
+  it('parses a LinkedIn profile URL', () => {
+    const result = parse('https://linkedin.com/in/jane-doe')
+    expect(result).toEqual({
+      platform: 'linkedin',
+      type: 'profile',
+      entities: { username: 'jane-doe' },
+      url: 'https://linkedin.com/in/jane-doe',
+    })
+  })
+
+  it('parses a Threads post URL', () => {
+    const result = parse('https://threads.net/@johndoe/post/abc123')
+    expect(result).toEqual({
+      platform: 'threads',
+      type: 'post',
+      entities: { username: 'johndoe', post_id: 'abc123' },
+      url: 'https://threads.net/@johndoe/post/abc123',
+    })
+  })
+
+  it('parses a Bluesky post URL', () => {
+    const result = parse('https://bsky.app/profile/alice.bsky.social/post/3kxy9')
+    expect(result).toEqual({
+      platform: 'bluesky',
+      type: 'post',
+      entities: { handle_or_did: 'alice.bsky.social', post_id: '3kxy9' },
+      url: 'https://bsky.app/profile/alice.bsky.social/post/3kxy9',
+    })
+  })
+
+  it('parses a Pinterest board URL', () => {
+    const result = parse('https://pinterest.com/johndoe/home-decor')
+    expect(result).toEqual({
+      platform: 'pinterest',
+      type: 'board',
+      entities: { username: 'johndoe', board: 'home-decor' },
+      url: 'https://pinterest.com/johndoe/home-decor',
+    })
+  })
+
+  it('parses a Twitch clip URL', () => {
+    const result = parse('https://clips.twitch.tv/AmazingClipSlug')
+    expect(result).toEqual({
+      platform: 'twitch',
+      type: 'clip',
+      entities: { clip_id: 'AmazingClipSlug' },
+      url: 'https://clips.twitch.tv/AmazingClipSlug',
+    })
+  })
+
+  it('parses a Telegram channel post URL', () => {
+    const result = parse('https://t.me/openai/123')
+    expect(result).toEqual({
+      platform: 'telegram',
+      type: 'post',
+      entities: { channel: 'openai', post_id: '123' },
+      url: 'https://t.me/openai/123',
+    })
+  })
+
+  it('parses a Snapchat spotlight URL', () => {
+    const result = parse('https://snapchat.com/spotlight/abc123')
+    expect(result).toEqual({
+      platform: 'snapchat',
+      type: 'short',
+      entities: { video_id: 'abc123' },
+      url: 'https://snapchat.com/spotlight/abc123',
+    })
+  })
+
+  it('parses a Vimeo URL', () => {
+    const result = parse('https://vimeo.com/123456789')
+    expect(result).toEqual({
+      platform: 'vimeo',
+      type: 'video',
+      entities: { video_id: '123456789' },
+      url: 'https://vimeo.com/123456789',
+    })
+  })
+
+  it('parses a Dailymotion URL', () => {
+    const result = parse('https://dailymotion.com/video/x9abcde')
+    expect(result).toEqual({
+      platform: 'dailymotion',
+      type: 'video',
+      entities: { video_id: 'x9abcde' },
+      url: 'https://dailymotion.com/video/x9abcde',
+    })
+  })
+
+  it('strips tracking params', () => {
+    const result = parse('https://twitter.com/user/status/123?utm_source=share&utm_medium=web')
+    expect(result).not.toBeNull()
+    expect(result!.url).not.toContain('utm_source')
+  })
+
+  it('returns null for invalid input', () => {
+    expect(parse('')).toBeNull()
+    expect(parse('not a url')).toBeNull()
+  })
+
+  it('returns null for unknown domains', () => {
+    expect(parse('https://example.com/path')).toBeNull()
+  })
+
+  it('returns null when domain matches but path does not', () => {
+    expect(parse('https://twitter.com/home')).toBeNull()
+  })
+
+  it('accepts custom parsers', () => {
+    const result = parse('https://twitter.com/user123', [])
+    expect(result).toBeNull()
+  })
+})
+
+describe('identify', () => {
+  it('identifies twitter', () => {
+    expect(identify('https://x.com/elonmusk')).toBe('twitter')
+  })
+
+  it('identifies instagram', () => {
+    expect(identify('https://instagram.com/johndoe')).toBe('instagram')
+  })
+
+  it('returns null for unknown', () => {
+    expect(identify('https://example.com')).toBeNull()
+  })
+
+  it('returns null for invalid input', () => {
+    expect(identify('')).toBeNull()
+  })
+
+  it('accepts custom parsers', () => {
+    expect(identify('https://x.com/user123', [])).toBeNull()
+  })
+})
+
+describe('normalize', () => {
+  it('normalizes a Twitter URL', () => {
+    expect(normalize('https://twitter.com/elonmusk/status/123')).toBe('https://x.com/i/status/123')
+  })
+
+  it('normalizes an Instagram URL with www', () => {
+    expect(normalize('https://www.instagram.com/johndoe/')).toBe('https://instagram.com/johndoe')
+  })
+
+  it('returns null for unknown', () => {
+    expect(normalize('https://example.com')).toBeNull()
+  })
+
+  it('returns null for invalid input', () => {
+    expect(normalize('')).toBeNull()
+  })
+
+  it('accepts custom parsers', () => {
+    expect(normalize('https://x.com/user123', [])).toBeNull()
+  })
+})

--- a/test/instagram.test.ts
+++ b/test/instagram.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import { instagram } from '../src/parsers/instagram'
+
+function parse(urlStr: string) {
+  return instagram.parse(new URL(urlStr))
+}
+
+describe('instagram', () => {
+  describe('domains', () => {
+    it('matches instagram.com', () => expect(instagram.domains('instagram.com')).toBe(true))
+    it('matches www.instagram.com', () => expect(instagram.domains('www.instagram.com')).toBe(true))
+    it('rejects unrelated domains', () => expect(instagram.domains('notinstagram.com')).toBe(false))
+  })
+
+  describe('post', () => {
+    it('parses /p/{shortcode}', () => {
+      expect(parse('https://instagram.com/p/ABC123')).toEqual({
+        type: 'post',
+        entities: { post_id: 'ABC123' },
+        url: 'https://instagram.com/p/ABC123',
+      })
+    })
+
+    it('parses /reel/{shortcode}', () => {
+      expect(parse('https://instagram.com/reel/ABC123')).toEqual({
+        type: 'post',
+        entities: { post_id: 'ABC123' },
+        url: 'https://instagram.com/p/ABC123',
+      })
+    })
+
+    it('parses /reels/{shortcode}', () => {
+      expect(parse('https://instagram.com/reels/ABC123')).toEqual({
+        type: 'post',
+        entities: { post_id: 'ABC123' },
+        url: 'https://instagram.com/p/ABC123',
+      })
+    })
+
+    it('parses /tv/{shortcode}', () => {
+      expect(parse('https://instagram.com/tv/ABC123')).toEqual({
+        type: 'post',
+        entities: { post_id: 'ABC123' },
+        url: 'https://instagram.com/p/ABC123',
+      })
+    })
+
+    it('parses /{user}/p/{shortcode}', () => {
+      expect(parse('https://instagram.com/johndoe/p/ABC123')).toEqual({
+        type: 'post',
+        entities: { post_id: 'ABC123', username: 'johndoe' },
+        url: 'https://instagram.com/p/ABC123',
+      })
+    })
+
+    it('parses /{user}/reel/{shortcode}', () => {
+      const result = parse('https://instagram.com/johndoe/reel/XYZ789')
+      expect(result!.type).toBe('post')
+      expect(result!.entities.post_id).toBe('XYZ789')
+      expect(result!.entities.username).toBe('johndoe')
+    })
+  })
+
+  describe('story', () => {
+    it('parses /stories/{username}/{id}', () => {
+      expect(parse('https://instagram.com/stories/johndoe/1234567890')).toEqual({
+        type: 'story',
+        entities: { username: 'johndoe', story_id: '1234567890' },
+        url: 'https://instagram.com/stories/johndoe/1234567890',
+      })
+    })
+
+    it('rejects /stories/highlights/', () => {
+      expect(parse('https://instagram.com/stories/highlights/12345')).toBeNull()
+    })
+
+    it('rejects non-numeric story IDs', () => {
+      expect(parse('https://instagram.com/stories/user/abc')).toBeNull()
+    })
+  })
+
+  describe('profile', () => {
+    it('parses /{username}', () => {
+      expect(parse('https://instagram.com/johndoe')).toEqual({
+        type: 'profile',
+        entities: { username: 'johndoe' },
+        url: 'https://instagram.com/johndoe',
+      })
+    })
+
+    it('allows dots in username', () => {
+      const result = parse('https://instagram.com/john.doe')
+      expect(result).not.toBeNull()
+      expect(result!.entities.username).toBe('john.doe')
+    })
+
+    it('rejects username starting with dot', () => {
+      expect(parse('https://instagram.com/.johndoe')).toBeNull()
+    })
+
+    it('rejects username ending with dot', () => {
+      expect(parse('https://instagram.com/johndoe.')).toBeNull()
+    })
+
+    it('rejects reserved paths', () => {
+      expect(parse('https://instagram.com/explore')).toBeNull()
+      expect(parse('https://instagram.com/accounts')).toBeNull()
+      expect(parse('https://instagram.com/direct')).toBeNull()
+      expect(parse('https://instagram.com/settings')).toBeNull()
+    })
+
+    it('rejects multi-segment paths as profiles', () => {
+      expect(parse('https://instagram.com/user/followers')).toBeNull()
+    })
+
+    it('does not misidentify a post URL as a profile', () => {
+      const result = parse('https://instagram.com/nikuscs/p/ABC123')
+      expect(result!.type).toBe('post')
+      expect(result!.entities.post_id).toBe('ABC123')
+      expect(result!.entities.username).toBe('nikuscs')
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for root path', () => {
+      expect(parse('https://instagram.com/')).toBeNull()
+    })
+
+    it('returns null for /stories alone', () => {
+      expect(parse('https://instagram.com/stories')).toBeNull()
+    })
+
+    it('returns null for post URLs with extra trailing segments', () => {
+      expect(parse('https://instagram.com/nikuscs/p/ABC123/extra')).toBeNull()
+    })
+  })
+})

--- a/test/linkedin.test.ts
+++ b/test/linkedin.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { linkedin } from '../src/parsers/linkedin'
+
+function parse(urlStr: string) {
+  return linkedin.parse(new URL(urlStr))
+}
+
+describe('linkedin', () => {
+  describe('domains', () => {
+    it('matches linkedin.com', () => expect(linkedin.domains('linkedin.com')).toBe(true))
+    it('matches www.linkedin.com', () => expect(linkedin.domains('www.linkedin.com')).toBe(true))
+    it('rejects unrelated domains', () => expect(linkedin.domains('notlinkedin.com')).toBe(false))
+  })
+
+  describe('profile', () => {
+    it('parses /in/{username}', () => {
+      expect(parse('https://linkedin.com/in/jane-doe')).toEqual({
+        type: 'profile',
+        entities: { username: 'jane-doe' },
+        url: 'https://linkedin.com/in/jane-doe',
+      })
+    })
+
+    it('parses /company/{company}', () => {
+      expect(parse('https://linkedin.com/company/openai')).toEqual({
+        type: 'profile',
+        entities: { company: 'openai' },
+        url: 'https://linkedin.com/company/openai',
+      })
+    })
+  })
+
+  describe('post', () => {
+    it('parses /posts/{id}', () => {
+      expect(parse('https://linkedin.com/posts/acme_abc123')).toEqual({
+        type: 'post',
+        entities: { post_id: 'acme_abc123' },
+        url: 'https://linkedin.com/posts/acme_abc123',
+      })
+    })
+
+    it('parses /feed/update/{urn}', () => {
+      expect(parse('https://linkedin.com/feed/update/urn:li:activity:123')).toEqual({
+        type: 'post',
+        entities: { post_id: 'urn:li:activity:123' },
+        url: 'https://linkedin.com/feed/update/urn:li:activity:123',
+      })
+    })
+
+    it('parses /feed/update?updateEntityUrn={urn}', () => {
+      expect(parse('https://linkedin.com/feed/update?updateEntityUrn=urn:li:activity:456')).toEqual({
+        type: 'post',
+        entities: { post_id: 'urn:li:activity:456' },
+        url: 'https://linkedin.com/feed/update/urn:li:activity:456',
+      })
+    })
+
+    it('returns null for /feed/update without urn', () => {
+      expect(parse('https://linkedin.com/feed/update')).toBeNull()
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for unrecognized paths', () => {
+      expect(parse('https://linkedin.com/jobs/view/123')).toBeNull()
+    })
+  })
+})

--- a/test/pinterest.test.ts
+++ b/test/pinterest.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { pinterest } from '../src/parsers/pinterest'
+
+function parse(urlStr: string) {
+  return pinterest.parse(new URL(urlStr))
+}
+
+describe('pinterest', () => {
+  describe('domains', () => {
+    it('matches pinterest.com', () => expect(pinterest.domains('pinterest.com')).toBe(true))
+    it('matches www.pinterest.com', () => expect(pinterest.domains('www.pinterest.com')).toBe(true))
+    it('rejects unrelated domains', () => expect(pinterest.domains('example.com')).toBe(false))
+  })
+
+  describe('pin', () => {
+    it('parses /pin/{id}', () => {
+      expect(parse('https://pinterest.com/pin/123456789')).toEqual({
+        type: 'photo',
+        entities: { pin_id: '123456789' },
+        url: 'https://pinterest.com/pin/123456789',
+      })
+    })
+
+    it('rejects non-numeric pin ids', () => {
+      expect(parse('https://pinterest.com/pin/abc')).toBeNull()
+    })
+  })
+
+  describe('board', () => {
+    it('parses /{username}/{board}', () => {
+      expect(parse('https://pinterest.com/johndoe/home-decor')).toEqual({
+        type: 'board',
+        entities: { username: 'johndoe', board: 'home-decor' },
+        url: 'https://pinterest.com/johndoe/home-decor',
+      })
+    })
+  })
+
+  describe('profile', () => {
+    it('parses /{username}', () => {
+      expect(parse('https://pinterest.com/johndoe')).toEqual({
+        type: 'profile',
+        entities: { username: 'johndoe' },
+        url: 'https://pinterest.com/johndoe',
+      })
+    })
+
+    it('rejects reserved paths', () => {
+      expect(parse('https://pinterest.com/search')).toBeNull()
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for unknown paths', () => {
+      expect(parse('https://pinterest.com/johndoe/home-decor/extra')).toBeNull()
+    })
+  })
+})

--- a/test/reddit.test.ts
+++ b/test/reddit.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+import { reddit } from '../src/parsers/reddit'
+
+function parse(urlStr: string) {
+  return reddit.parse(new URL(urlStr))
+}
+
+describe('reddit', () => {
+  describe('domains', () => {
+    it('matches reddit.com', () => expect(reddit.domains('reddit.com')).toBe(true))
+    it('matches old.reddit.com', () => expect(reddit.domains('old.reddit.com')).toBe(true))
+    it('matches www.reddit.com', () => expect(reddit.domains('www.reddit.com')).toBe(true))
+    it('matches i.redd.it', () => expect(reddit.domains('i.redd.it')).toBe(true))
+    it('matches v.redd.it', () => expect(reddit.domains('v.redd.it')).toBe(true))
+    it('matches redd.it short domain', () => expect(reddit.domains('redd.it')).toBe(true))
+    it('rejects unrelated domains', () => expect(reddit.domains('notreddit.com')).toBe(false))
+  })
+
+  describe('comment', () => {
+    it('parses /r/{sub}/comments/{post_id}/{slug}/{comment_id}', () => {
+      expect(parse('https://reddit.com/r/typescript/comments/abc12345/my_post/abcdefg0')).toEqual({
+        type: 'comment',
+        entities: {
+          subreddit: 'typescript',
+          post_id: 'abc12345',
+          comment_id: 'abcdefg0',
+        },
+        url: 'https://reddit.com/r/typescript/comments/abc12345/_/abcdefg0',
+      })
+    })
+
+    it('rejects comment IDs shorter than 7 chars', () => {
+      const result = parse('https://reddit.com/r/test/comments/abc12345/slug/abcdef')
+      // This has 6-char comment ID, won't match comment pattern, will fall through to post
+      expect(result?.type).toBe('post')
+    })
+  })
+
+  describe('post', () => {
+    it('parses redd.it/{id}', () => {
+      expect(parse('https://redd.it/abc12345')).toEqual({
+        type: 'post',
+        entities: { post_id: 'abc12345' },
+        url: 'https://reddit.com/comments/abc12345',
+      })
+    })
+
+    it('parses /comments/{id}', () => {
+      expect(parse('https://reddit.com/comments/abc12345')).toEqual({
+        type: 'post',
+        entities: { post_id: 'abc12345' },
+        url: 'https://reddit.com/comments/abc12345',
+      })
+    })
+
+    it('parses /comments/{id}/{slug}', () => {
+      expect(parse('https://reddit.com/comments/abc12345/my_post')).toEqual({
+        type: 'post',
+        entities: { post_id: 'abc12345' },
+        url: 'https://reddit.com/comments/abc12345',
+      })
+    })
+
+    it('parses /comments/{id}/{slug}/{comment_id}', () => {
+      expect(parse('https://reddit.com/comments/abc12345/my_post/abcdefg0')).toEqual({
+        type: 'comment',
+        entities: { post_id: 'abc12345', comment_id: 'abcdefg0' },
+        url: 'https://reddit.com/comments/abc12345/_/abcdefg0',
+      })
+    })
+
+    it('parses /comments/{id}/{comment_id}', () => {
+      expect(parse('https://reddit.com/comments/abc12345/abcdefg0')).toEqual({
+        type: 'comment',
+        entities: { post_id: 'abc12345', comment_id: 'abcdefg0' },
+        url: 'https://reddit.com/comments/abc12345/_/abcdefg0',
+      })
+    })
+
+    it('parses /r/{sub}/comments/{id}', () => {
+      expect(parse('https://reddit.com/r/typescript/comments/abc12345')).toEqual({
+        type: 'post',
+        entities: { subreddit: 'typescript', post_id: 'abc12345' },
+        url: 'https://reddit.com/r/typescript/comments/abc12345',
+      })
+    })
+
+    it('parses /r/{sub}/comments/{id}/{slug}', () => {
+      expect(parse('https://reddit.com/r/typescript/comments/abc12345/my_post')).toEqual({
+        type: 'post',
+        entities: { subreddit: 'typescript', post_id: 'abc12345' },
+        url: 'https://reddit.com/r/typescript/comments/abc12345',
+      })
+    })
+
+    it('rejects post IDs shorter than 6 chars', () => {
+      expect(parse('https://reddit.com/r/test/comments/abc12')).toBeNull()
+    })
+
+    it('rejects post IDs longer than 10 chars', () => {
+      expect(parse('https://reddit.com/r/test/comments/abc12345678')).toBeNull()
+    })
+
+    it('rejects subreddits shorter than 3 chars', () => {
+      expect(parse('https://reddit.com/r/ab/comments/abc123')).toBeNull()
+    })
+
+    it('rejects subreddits longer than 21 chars', () => {
+      expect(parse('https://reddit.com/r/abcdefghijklmnopqrstuv/comments/abc123')).toBeNull()
+    })
+  })
+
+  describe('profile', () => {
+    it('parses /user/{name}', () => {
+      expect(parse('https://reddit.com/user/johndoe')).toEqual({
+        type: 'profile',
+        entities: { username: 'johndoe' },
+        url: 'https://reddit.com/user/johndoe',
+      })
+    })
+
+    it('parses /u/{name}', () => {
+      expect(parse('https://reddit.com/u/johndoe')).toEqual({
+        type: 'profile',
+        entities: { username: 'johndoe' },
+        url: 'https://reddit.com/user/johndoe',
+      })
+    })
+
+    it('allows hyphens in username', () => {
+      const result = parse('https://reddit.com/user/john-doe')
+      expect(result).not.toBeNull()
+      expect(result!.entities.username).toBe('john-doe')
+    })
+
+    it('rejects all-dash usernames', () => {
+      expect(parse('https://reddit.com/user/---')).toBeNull()
+    })
+
+    it('rejects usernames shorter than 3 chars', () => {
+      expect(parse('https://reddit.com/user/ab')).toBeNull()
+    })
+
+    it('rejects usernames longer than 20 chars', () => {
+      expect(parse('https://reddit.com/user/abcdefghijklmnopqrstu')).toBeNull()
+    })
+  })
+
+  describe('subreddit', () => {
+    it('parses /r/{name}', () => {
+      expect(parse('https://reddit.com/r/typescript')).toEqual({
+        type: 'subreddit',
+        entities: { subreddit: 'typescript' },
+        url: 'https://reddit.com/r/typescript',
+      })
+    })
+
+    it('rejects /r alone', () => {
+      expect(parse('https://reddit.com/r')).toBeNull()
+    })
+
+    it('rejects subreddit names with invalid chars', () => {
+      expect(parse('https://reddit.com/r/type-script')).toBeNull()
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for root path', () => {
+      expect(parse('https://reddit.com/')).toBeNull()
+    })
+
+    it('returns null for unrecognized paths', () => {
+      expect(parse('https://reddit.com/random/path')).toBeNull()
+    })
+
+    it('returns null for /user with extra segments', () => {
+      expect(parse('https://reddit.com/user/john/posts')).toBeNull()
+    })
+  })
+})

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { search } from '../src/parsers/search'
+
+function parse(urlStr: string) {
+  return search.parse(new URL(urlStr))
+}
+
+describe('search', () => {
+  describe('domains', () => {
+    it('matches google.com', () => expect(search.domains('google.com')).toBe(true))
+    it('matches www.google.com', () => expect(search.domains('www.google.com')).toBe(true))
+    it('matches bing.com', () => expect(search.domains('bing.com')).toBe(true))
+    it('matches duckduckgo.com', () => expect(search.domains('duckduckgo.com')).toBe(true))
+    it('matches yahoo.com', () => expect(search.domains('yahoo.com')).toBe(true))
+    it('matches yandex.com', () => expect(search.domains('yandex.com')).toBe(true))
+    it('matches baidu.com', () => expect(search.domains('baidu.com')).toBe(true))
+    it('matches brave.com', () => expect(search.domains('brave.com')).toBe(true))
+    it('matches search.brave.com', () => expect(search.domains('search.brave.com')).toBe(true))
+    it('matches ecosia.org', () => expect(search.domains('ecosia.org')).toBe(true))
+    it('matches qwant.com', () => expect(search.domains('qwant.com')).toBe(true))
+    it('matches startpage.com', () => expect(search.domains('startpage.com')).toBe(true))
+    it('matches regional google domains', () => {
+      expect(search.domains('google.co.uk')).toBe(true)
+      expect(search.domains('google.de')).toBe(true)
+      expect(search.domains('google.co.jp')).toBe(true)
+    })
+    it('matches subdomains of search engines', () => {
+      expect(search.domains('www.bing.com')).toBe(true)
+      expect(search.domains('www.baidu.com')).toBe(true)
+    })
+    it('rejects unrelated domains', () => expect(search.domains('example.com')).toBe(false))
+  })
+
+  describe('search query', () => {
+    it('extracts q param from Google', () => {
+      expect(parse('https://google.com/search?q=hello+world')).toEqual({
+        type: 'search',
+        entities: { query: 'hello world' },
+        url: 'https://google.com/search?q=hello+world',
+      })
+    })
+
+    it('extracts q param from Bing', () => {
+      const result = parse('https://bing.com/search?q=test')
+      expect(result).not.toBeNull()
+      expect(result!.entities.query).toBe('test')
+    })
+
+    it('extracts q param from DuckDuckGo', () => {
+      const result = parse('https://duckduckgo.com/?q=test')
+      expect(result).not.toBeNull()
+      expect(result!.entities.query).toBe('test')
+    })
+
+    it('extracts p param from Yahoo', () => {
+      expect(parse('https://search.yahoo.com/search?p=hello')).toEqual({
+        type: 'search',
+        entities: { query: 'hello' },
+        url: 'https://search.yahoo.com/search?p=hello',
+      })
+    })
+
+    it('extracts text param from Yandex', () => {
+      expect(parse('https://yandex.com/search/?text=hello+world')).toEqual({
+        type: 'search',
+        entities: { query: 'hello world' },
+        url: 'https://yandex.com/search/?text=hello+world',
+      })
+    })
+
+    it('extracts wd param from Baidu', () => {
+      expect(parse('https://baidu.com/s?wd=hello')).toEqual({
+        type: 'search',
+        entities: { query: 'hello' },
+        url: 'https://baidu.com/s?wd=hello',
+      })
+    })
+
+    it('extracts wd param from Baidu subdomain', () => {
+      const result = parse('https://www.baidu.com/s?wd=test')
+      expect(result).not.toBeNull()
+      expect(result!.entities.query).toBe('test')
+    })
+
+    it('returns null when no query param present', () => {
+      expect(parse('https://google.com/')).toBeNull()
+    })
+
+    it('returns null for Baidu without wd param', () => {
+      expect(parse('https://baidu.com/s?q=test')).toBeNull()
+    })
+
+    it('falls back to q for Yahoo when p is missing', () => {
+      expect(parse('https://search.yahoo.com/search?q=test')).toEqual({
+        type: 'search',
+        entities: { query: 'test' },
+        url: 'https://search.yahoo.com/search?q=test',
+      })
+    })
+
+    it('falls back to q for Yandex when text is missing', () => {
+      expect(parse('https://yandex.com/search/?q=test')).toEqual({
+        type: 'search',
+        entities: { query: 'test' },
+        url: 'https://yandex.com/search/?q=test',
+      })
+    })
+  })
+})

--- a/test/snapchat.test.ts
+++ b/test/snapchat.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { snapchat } from '../src/parsers/snapchat'
+
+function parse(urlStr: string) {
+  return snapchat.parse(new URL(urlStr))
+}
+
+describe('snapchat', () => {
+  describe('domains', () => {
+    it('matches snapchat.com', () => expect(snapchat.domains('snapchat.com')).toBe(true))
+    it('matches subdomains of snapchat.com', () => expect(snapchat.domains('story.snapchat.com')).toBe(true))
+    it('rejects unrelated domains', () => expect(snapchat.domains('example.com')).toBe(false))
+  })
+
+  describe('profile', () => {
+    it('parses /add/{username}', () => {
+      expect(parse('https://snapchat.com/add/johndoe')).toEqual({
+        type: 'profile',
+        entities: { username: 'johndoe' },
+        url: 'https://snapchat.com/add/johndoe',
+      })
+    })
+  })
+
+  describe('spotlight', () => {
+    it('parses /spotlight/{id}', () => {
+      expect(parse('https://snapchat.com/spotlight/abc123')).toEqual({
+        type: 'short',
+        entities: { video_id: 'abc123' },
+        url: 'https://snapchat.com/spotlight/abc123',
+      })
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for unsupported paths', () => {
+      expect(parse('https://snapchat.com/discover')).toBeNull()
+    })
+  })
+})

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { telegram } from '../src/parsers/telegram'
+
+function parse(urlStr: string) {
+  return telegram.parse(new URL(urlStr))
+}
+
+describe('telegram', () => {
+  describe('domains', () => {
+    it('matches t.me', () => expect(telegram.domains('t.me')).toBe(true))
+    it('matches telegram.me', () => expect(telegram.domains('telegram.me')).toBe(true))
+    it('rejects unrelated domains', () => expect(telegram.domains('example.com')).toBe(false))
+  })
+
+  describe('group invite', () => {
+    it('parses /+{invite_code}', () => {
+      expect(parse('https://t.me/+abcdef123')).toEqual({
+        type: 'group',
+        entities: { invite_code: 'abcdef123' },
+        url: 'https://t.me/+abcdef123',
+      })
+    })
+
+    it('parses /joinchat/{invite_code}', () => {
+      expect(parse('https://t.me/joinchat/abcdef123')).toEqual({
+        type: 'group',
+        entities: { invite_code: 'abcdef123' },
+        url: 'https://t.me/joinchat/abcdef123',
+      })
+    })
+  })
+
+  describe('post', () => {
+    it('parses /{channel}/{post_id}', () => {
+      expect(parse('https://t.me/openai/123')).toEqual({
+        type: 'post',
+        entities: { channel: 'openai', post_id: '123' },
+        url: 'https://t.me/openai/123',
+      })
+    })
+
+    it('parses /s/{channel}/{post_id}', () => {
+      expect(parse('https://t.me/s/openai/123')).toEqual({
+        type: 'post',
+        entities: { channel: 'openai', post_id: '123' },
+        url: 'https://t.me/openai/123',
+      })
+    })
+  })
+
+  describe('profile', () => {
+    it('parses /{channel}', () => {
+      expect(parse('https://t.me/openai')).toEqual({
+        type: 'profile',
+        entities: { username: 'openai' },
+        url: 'https://t.me/openai',
+      })
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for invalid /s path', () => {
+      expect(parse('https://t.me/s/openai/not-a-number')).toBeNull()
+    })
+
+    it('returns null for incomplete joinchat path', () => {
+      expect(parse('https://t.me/joinchat')).toBeNull()
+    })
+  })
+})

--- a/test/threads.test.ts
+++ b/test/threads.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { threads } from '../src/parsers/threads'
+
+function parse(urlStr: string) {
+  return threads.parse(new URL(urlStr))
+}
+
+describe('threads', () => {
+  describe('domains', () => {
+    it('matches threads.net', () => expect(threads.domains('threads.net')).toBe(true))
+    it('matches www.threads.net', () => expect(threads.domains('www.threads.net')).toBe(true))
+    it('rejects unrelated domains', () => expect(threads.domains('example.com')).toBe(false))
+  })
+
+  describe('post', () => {
+    it('parses /@{username}/post/{id}', () => {
+      expect(parse('https://threads.net/@johndoe/post/abc123')).toEqual({
+        type: 'post',
+        entities: { username: 'johndoe', post_id: 'abc123' },
+        url: 'https://threads.net/@johndoe/post/abc123',
+      })
+    })
+  })
+
+  describe('profile', () => {
+    it('parses /@{username}', () => {
+      expect(parse('https://threads.net/@johndoe')).toEqual({
+        type: 'profile',
+        entities: { username: 'johndoe' },
+        url: 'https://threads.net/@johndoe',
+      })
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for empty @ handle', () => {
+      expect(parse('https://threads.net/@')).toBeNull()
+    })
+
+    it('returns null for unsupported paths', () => {
+      expect(parse('https://threads.net/trending')).toBeNull()
+      expect(parse('https://threads.net/@johndoe/replies')).toBeNull()
+    })
+  })
+})

--- a/test/tiktok.test.ts
+++ b/test/tiktok.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { tiktok } from '../src/parsers/tiktok'
+
+function parse(urlStr: string) {
+  return tiktok.parse(new URL(urlStr))
+}
+
+describe('tiktok', () => {
+  describe('domains', () => {
+    it('matches tiktok.com', () => expect(tiktok.domains('tiktok.com')).toBe(true))
+    it('matches www.tiktok.com', () => expect(tiktok.domains('www.tiktok.com')).toBe(true))
+    it('matches vm.tiktok.com', () => expect(tiktok.domains('vm.tiktok.com')).toBe(true))
+    it('matches vt.tiktok.com', () => expect(tiktok.domains('vt.tiktok.com')).toBe(true))
+    it('rejects unrelated domains', () => expect(tiktok.domains('nottiktok.com')).toBe(false))
+  })
+
+  describe('video', () => {
+    it('parses /@{user}/video/{id}', () => {
+      expect(parse('https://tiktok.com/@username/video/123456789012345678')).toEqual({
+        type: 'video',
+        entities: { video_id: '123456789012345678', username: 'username' },
+        url: 'https://tiktok.com/@username/video/123456789012345678',
+      })
+    })
+
+    it('accepts 20-digit video IDs', () => {
+      const result = parse('https://tiktok.com/@user/video/12345678901234567890')
+      expect(result).not.toBeNull()
+      expect(result!.entities.video_id).toBe('12345678901234567890')
+    })
+
+    it('rejects video IDs shorter than 18 digits', () => {
+      expect(parse('https://tiktok.com/@user/video/12345678901234567')).toBeNull()
+    })
+
+    it('rejects video IDs longer than 20 digits', () => {
+      expect(parse('https://tiktok.com/@user/video/123456789012345678901')).toBeNull()
+    })
+
+    it('rejects non-numeric video IDs', () => {
+      expect(parse('https://tiktok.com/@user/video/abc456789012345678')).toBeNull()
+    })
+
+    it('parses /video/{id}', () => {
+      expect(parse('https://www.tiktok.com/video/123456789012345678')).toEqual({
+        type: 'video',
+        entities: { video_id: '123456789012345678' },
+        url: 'https://tiktok.com/video/123456789012345678',
+      })
+    })
+
+    it('parses vm.tiktok.com links with share_item_id', () => {
+      expect(parse('https://vm.tiktok.com/ZSabc/?share_item_id=123456789012345678')).toEqual({
+        type: 'video',
+        entities: { video_id: '123456789012345678' },
+        url: 'https://tiktok.com/video/123456789012345678',
+      })
+    })
+
+    it('parses vt.tiktok.com links with item_id', () => {
+      expect(parse('https://vt.tiktok.com/ZSabc/?item_id=12345678901234567890')).toEqual({
+        type: 'video',
+        entities: { video_id: '12345678901234567890' },
+        url: 'https://tiktok.com/video/12345678901234567890',
+      })
+    })
+
+    it('returns null for vm.tiktok.com links without item ids', () => {
+      expect(parse('https://vm.tiktok.com/ZSabc/')).toBeNull()
+    })
+
+    it('returns null for vm.tiktok.com links with invalid item ids', () => {
+      expect(parse('https://vm.tiktok.com/ZSabc/?share_item_id=not-numeric')).toBeNull()
+    })
+  })
+
+  describe('profile', () => {
+    it('parses /@{username}', () => {
+      expect(parse('https://tiktok.com/@johndoe')).toEqual({
+        type: 'profile',
+        entities: { username: 'johndoe' },
+        url: 'https://tiktok.com/@johndoe',
+      })
+    })
+
+    it('allows dots in username', () => {
+      const result = parse('https://tiktok.com/@john.doe')
+      expect(result).not.toBeNull()
+      expect(result!.entities.username).toBe('john.doe')
+    })
+
+    it('rejects username starting with dot', () => {
+      expect(parse('https://tiktok.com/@.johndoe')).toBeNull()
+    })
+
+    it('rejects username ending with dot', () => {
+      expect(parse('https://tiktok.com/@johndoe.')).toBeNull()
+    })
+
+    it('rejects reserved paths (without @)', () => {
+      // Reserved paths don't start with @ so they won't match anyway
+      expect(parse('https://tiktok.com/explore')).toBeNull()
+    })
+
+    it('rejects paths without @', () => {
+      expect(parse('https://tiktok.com/username')).toBeNull()
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for root path', () => {
+      expect(parse('https://tiktok.com/')).toBeNull()
+    })
+
+    it('returns null for multi-segment non-video paths', () => {
+      expect(parse('https://tiktok.com/@user/likes')).toBeNull()
+    })
+  })
+})

--- a/test/twitch.test.ts
+++ b/test/twitch.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { twitch } from '../src/parsers/twitch'
+
+function parse(urlStr: string) {
+  return twitch.parse(new URL(urlStr))
+}
+
+describe('twitch', () => {
+  describe('domains', () => {
+    it('matches twitch.tv', () => expect(twitch.domains('twitch.tv')).toBe(true))
+    it('matches subdomains of twitch.tv', () => expect(twitch.domains('www.twitch.tv')).toBe(true))
+    it('matches clips.twitch.tv', () => expect(twitch.domains('clips.twitch.tv')).toBe(true))
+    it('rejects unrelated domains', () => expect(twitch.domains('example.com')).toBe(false))
+  })
+
+  describe('video', () => {
+    it('parses /videos/{id}', () => {
+      expect(parse('https://twitch.tv/videos/123456789')).toEqual({
+        type: 'video',
+        entities: { video_id: '123456789' },
+        url: 'https://twitch.tv/videos/123456789',
+      })
+    })
+
+    it('rejects non-numeric video ids', () => {
+      expect(parse('https://twitch.tv/videos/not-a-number')).toBeNull()
+    })
+  })
+
+  describe('clip', () => {
+    it('parses clips.twitch.tv/{slug}', () => {
+      expect(parse('https://clips.twitch.tv/AmazingClipSlug')).toEqual({
+        type: 'clip',
+        entities: { clip_id: 'AmazingClipSlug' },
+        url: 'https://clips.twitch.tv/AmazingClipSlug',
+      })
+    })
+
+    it('parses /{channel}/clip/{slug}', () => {
+      expect(parse('https://twitch.tv/johndoe/clip/AmazingClipSlug')).toEqual({
+        type: 'clip',
+        entities: { username: 'johndoe', clip_id: 'AmazingClipSlug' },
+        url: 'https://twitch.tv/johndoe/clip/AmazingClipSlug',
+      })
+    })
+  })
+
+  describe('profile', () => {
+    it('parses /{channel}', () => {
+      expect(parse('https://twitch.tv/johndoe')).toEqual({
+        type: 'profile',
+        entities: { username: 'johndoe' },
+        url: 'https://twitch.tv/johndoe',
+      })
+    })
+
+    it('rejects reserved routes', () => {
+      expect(parse('https://twitch.tv/directory')).toBeNull()
+      expect(parse('https://twitch.tv/videos')).toBeNull()
+    })
+  })
+})

--- a/test/twitter.test.ts
+++ b/test/twitter.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { twitter } from '../src/parsers/twitter'
+
+function parse(urlStr: string) {
+  const url = new URL(urlStr)
+  return twitter.parse(url)
+}
+
+describe('twitter', () => {
+  describe('domains', () => {
+    it('matches twitter.com', () => expect(twitter.domains('twitter.com')).toBe(true))
+    it('matches x.com', () => expect(twitter.domains('x.com')).toBe(true))
+    it('matches subdomain of twitter.com', () => expect(twitter.domains('mobile.twitter.com')).toBe(true))
+    it('matches subdomain of x.com', () => expect(twitter.domains('mobile.x.com')).toBe(true))
+    it('rejects unrelated domains', () => expect(twitter.domains('notwitter.com')).toBe(false))
+    it('rejects partial match', () => expect(twitter.domains('fakex.com')).toBe(false))
+  })
+
+  describe('post', () => {
+    it('parses /i/status/{id} without treating i as username', () => {
+      const result = parse('https://x.com/i/status/1234567890')
+      expect(result).toEqual({
+        type: 'post',
+        entities: { post_id: '1234567890' },
+        url: 'https://x.com/i/status/1234567890',
+      })
+    })
+
+    it('parses /{user}/status/{id}', () => {
+      const result = parse('https://twitter.com/elonmusk/status/1234567890')
+      expect(result).toEqual({
+        type: 'post',
+        entities: { post_id: '1234567890', username: 'elonmusk' },
+        url: 'https://x.com/i/status/1234567890',
+      })
+    })
+
+    it('parses /i/web/status/{id}', () => {
+      const result = parse('https://x.com/i/web/status/1234567890')
+      expect(result).toEqual({
+        type: 'post',
+        entities: { post_id: '1234567890' },
+        url: 'https://x.com/i/status/1234567890',
+      })
+    })
+
+    it('parses posts with extra path segments', () => {
+      const result = parse('https://twitter.com/user/status/123456/photo/1')
+      expect(result).toEqual({
+        type: 'post',
+        entities: { post_id: '123456', username: 'user' },
+        url: 'https://x.com/i/status/123456',
+      })
+    })
+
+    it('rejects non-numeric post IDs', () => {
+      expect(parse('https://twitter.com/user/status/abc')).toBeNull()
+    })
+  })
+
+  describe('profile', () => {
+    it('parses /{username}', () => {
+      const result = parse('https://x.com/elonmusk')
+      expect(result).toEqual({
+        type: 'profile',
+        entities: { username: 'elonmusk' },
+        url: 'https://x.com/elonmusk',
+      })
+    })
+
+    it('allows underscores in username', () => {
+      const result = parse('https://x.com/elon_musk')
+      expect(result).not.toBeNull()
+      expect(result!.entities.username).toBe('elon_musk')
+    })
+
+    it('rejects usernames longer than 15 chars', () => {
+      expect(parse('https://x.com/abcdefghijklmnop')).toBeNull()
+    })
+
+    it('rejects reserved paths', () => {
+      expect(parse('https://x.com/home')).toBeNull()
+      expect(parse('https://x.com/explore')).toBeNull()
+      expect(parse('https://x.com/settings')).toBeNull()
+      expect(parse('https://x.com/search')).toBeNull()
+      expect(parse('https://x.com/login')).toBeNull()
+      expect(parse('https://x.com/messages')).toBeNull()
+    })
+
+    it('rejects usernames with invalid chars', () => {
+      expect(parse('https://x.com/user-name')).toBeNull()
+      expect(parse('https://x.com/user.name')).toBeNull()
+    })
+
+    it('rejects multi-segment paths as profiles', () => {
+      expect(parse('https://x.com/user/following')).toBeNull()
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for root path', () => {
+      expect(parse('https://x.com/')).toBeNull()
+    })
+
+    it('returns null for empty username', () => {
+      expect(parse('https://x.com')).toBeNull()
+    })
+  })
+})

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { tryParseUrl, cleanUrl } from '../src/url'
+
+describe('tryParseUrl', () => {
+  it('parses a full https URL', () => {
+    const url = tryParseUrl('https://example.com/path')
+    expect(url).not.toBeNull()
+    expect(url!.hostname).toBe('example.com')
+    expect(url!.pathname).toBe('/path')
+  })
+
+  it('parses a full http URL', () => {
+    const url = tryParseUrl('http://example.com')
+    expect(url).not.toBeNull()
+    expect(url!.protocol).toBe('http:')
+  })
+
+  it('prepends https:// to bare domains', () => {
+    const url = tryParseUrl('example.com/path')
+    expect(url).not.toBeNull()
+    expect(url!.protocol).toBe('https:')
+    expect(url!.hostname).toBe('example.com')
+  })
+
+  it('returns null for empty string', () => {
+    expect(tryParseUrl('')).toBeNull()
+  })
+
+  it('returns null for whitespace-only string', () => {
+    expect(tryParseUrl('   ')).toBeNull()
+  })
+
+  it('returns null for invalid URLs', () => {
+    expect(tryParseUrl('not a url at all ::: ////')).toBeNull()
+  })
+
+  it('trims whitespace', () => {
+    const url = tryParseUrl('  https://example.com  ')
+    expect(url).not.toBeNull()
+    expect(url!.hostname).toBe('example.com')
+  })
+})
+
+describe('cleanUrl', () => {
+  it('forces https protocol', () => {
+    const url = new URL('http://example.com')
+    const cleaned = cleanUrl(url)
+    expect(cleaned.protocol).toBe('https:')
+  })
+
+  it('lowercases hostname', () => {
+    const url = new URL('https://EXAMPLE.COM')
+    const cleaned = cleanUrl(url)
+    expect(cleaned.hostname).toBe('example.com')
+  })
+
+  it('removes fragments', () => {
+    const url = new URL('https://example.com/path#section')
+    const cleaned = cleanUrl(url)
+    expect(cleaned.hash).toBe('')
+  })
+
+  it('removes trailing slashes', () => {
+    const url = new URL('https://example.com/path/')
+    const cleaned = cleanUrl(url)
+    expect(cleaned.pathname).toBe('/path')
+  })
+
+  it('keeps root slash', () => {
+    const url = new URL('https://example.com/')
+    const cleaned = cleanUrl(url)
+    expect(cleaned.pathname).toBe('/')
+  })
+
+  it('removes tracking params', () => {
+    const url = new URL(
+      'https://example.com/path?utm_source=test&utm_medium=web&utm_campaign=camp&utm_term=t&utm_content=c&fbclid=abc&gclid=def&ref=ghi&si=jkl&s=mno&t=pqr&igshid=stu&keep=yes'
+    )
+    const cleaned = cleanUrl(url)
+    expect(cleaned.searchParams.has('utm_source')).toBe(false)
+    expect(cleaned.searchParams.has('utm_medium')).toBe(false)
+    expect(cleaned.searchParams.has('utm_campaign')).toBe(false)
+    expect(cleaned.searchParams.has('utm_term')).toBe(false)
+    expect(cleaned.searchParams.has('utm_content')).toBe(false)
+    expect(cleaned.searchParams.has('fbclid')).toBe(false)
+    expect(cleaned.searchParams.has('gclid')).toBe(false)
+    expect(cleaned.searchParams.has('ref')).toBe(false)
+    expect(cleaned.searchParams.has('si')).toBe(false)
+    expect(cleaned.searchParams.has('igshid')).toBe(false)
+    expect(cleaned.searchParams.get('s')).toBe('mno')
+    expect(cleaned.searchParams.get('t')).toBe('pqr')
+    expect(cleaned.searchParams.get('keep')).toBe('yes')
+  })
+
+  it('does not mutate the original URL', () => {
+    const url = new URL('http://EXAMPLE.COM/path/?utm_source=x#frag')
+    const original = url.href
+    cleanUrl(url)
+    expect(url.href).toBe(original)
+  })
+})

--- a/test/vimeo.test.ts
+++ b/test/vimeo.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { vimeo } from '../src/parsers/vimeo'
+
+function parse(urlStr: string) {
+  return vimeo.parse(new URL(urlStr))
+}
+
+describe('vimeo', () => {
+  describe('domains', () => {
+    it('matches vimeo.com', () => expect(vimeo.domains('vimeo.com')).toBe(true))
+    it('matches subdomains of vimeo.com', () => expect(vimeo.domains('player.vimeo.com')).toBe(true))
+    it('rejects unrelated domains', () => expect(vimeo.domains('example.com')).toBe(false))
+  })
+
+  describe('video', () => {
+    it('parses direct /{id}', () => {
+      expect(parse('https://vimeo.com/123456789')).toEqual({
+        type: 'video',
+        entities: { video_id: '123456789' },
+        url: 'https://vimeo.com/123456789',
+      })
+    })
+
+    it('parses /video/{id}', () => {
+      expect(parse('https://player.vimeo.com/video/123456789')).toEqual({
+        type: 'video',
+        entities: { video_id: '123456789' },
+        url: 'https://vimeo.com/123456789',
+      })
+    })
+
+    it('parses /channels/{channel}/{id}', () => {
+      expect(parse('https://vimeo.com/channels/staffpicks/123456789')).toEqual({
+        type: 'video',
+        entities: { channel: 'staffpicks', video_id: '123456789' },
+        url: 'https://vimeo.com/123456789',
+      })
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for unsupported paths', () => {
+      expect(parse('https://vimeo.com/channels/staffpicks')).toBeNull()
+      expect(parse('https://vimeo.com/not-a-video-id')).toBeNull()
+    })
+  })
+})

--- a/test/youtube.test.ts
+++ b/test/youtube.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import { youtube } from '../src/parsers/youtube'
+
+function parse(urlStr: string) {
+  return youtube.parse(new URL(urlStr))
+}
+
+describe('youtube', () => {
+  describe('domains', () => {
+    it('matches youtube.com', () => expect(youtube.domains('youtube.com')).toBe(true))
+    it('matches www.youtube.com', () => expect(youtube.domains('www.youtube.com')).toBe(true))
+    it('matches m.youtube.com', () => expect(youtube.domains('m.youtube.com')).toBe(true))
+    it('matches music.youtube.com', () => expect(youtube.domains('music.youtube.com')).toBe(true))
+    it('matches youtu.be', () => expect(youtube.domains('youtu.be')).toBe(true))
+    it('matches youtube-nocookie.com', () => expect(youtube.domains('youtube-nocookie.com')).toBe(true))
+    it('matches www.youtube-nocookie.com', () => expect(youtube.domains('www.youtube-nocookie.com')).toBe(true))
+    it('rejects unrelated domains', () => expect(youtube.domains('notyoutube.com')).toBe(false))
+  })
+
+  describe('video', () => {
+    it('parses /watch?v={id}', () => {
+      expect(parse('https://youtube.com/watch?v=dQw4w9WgXcQ')).toEqual({
+        type: 'video',
+        entities: { video_id: 'dQw4w9WgXcQ' },
+        url: 'https://youtube.com/watch?v=dQw4w9WgXcQ',
+      })
+    })
+
+    it('parses youtu.be/{id}', () => {
+      expect(parse('https://youtu.be/dQw4w9WgXcQ')).toEqual({
+        type: 'video',
+        entities: { video_id: 'dQw4w9WgXcQ' },
+        url: 'https://youtube.com/watch?v=dQw4w9WgXcQ',
+      })
+    })
+
+    it('parses /embed/{id}', () => {
+      expect(parse('https://youtube.com/embed/dQw4w9WgXcQ')).toEqual({
+        type: 'video',
+        entities: { video_id: 'dQw4w9WgXcQ' },
+        url: 'https://youtube.com/watch?v=dQw4w9WgXcQ',
+      })
+    })
+
+    it('parses youtube-nocookie embed URLs', () => {
+      expect(parse('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ')).toEqual({
+        type: 'video',
+        entities: { video_id: 'dQw4w9WgXcQ' },
+        url: 'https://youtube.com/watch?v=dQw4w9WgXcQ',
+      })
+    })
+
+    it('rejects invalid video IDs (wrong length)', () => {
+      expect(parse('https://youtube.com/watch?v=short')).toBeNull()
+      expect(parse('https://youtube.com/watch?v=toolong12345678')).toBeNull()
+    })
+
+    it('rejects /watch without v param', () => {
+      expect(parse('https://youtube.com/watch')).toBeNull()
+    })
+
+    it('rejects youtu.be with invalid ID', () => {
+      expect(parse('https://youtu.be/short')).toBeNull()
+    })
+
+    it('rejects /embed with invalid ID', () => {
+      expect(parse('https://youtube.com/embed/short')).toBeNull()
+    })
+  })
+
+  describe('short', () => {
+    it('parses /shorts/{id}', () => {
+      expect(parse('https://youtube.com/shorts/dQw4w9WgXcQ')).toEqual({
+        type: 'short',
+        entities: { video_id: 'dQw4w9WgXcQ' },
+        url: 'https://youtube.com/shorts/dQw4w9WgXcQ',
+      })
+    })
+
+    it('rejects shorts with invalid ID', () => {
+      expect(parse('https://youtube.com/shorts/short')).toBeNull()
+    })
+  })
+
+  describe('playlist', () => {
+    it('parses /playlist?list={id}', () => {
+      expect(parse('https://youtube.com/playlist?list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf')).toEqual({
+        type: 'playlist',
+        entities: { playlist_id: 'PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf' },
+        url: 'https://youtube.com/playlist?list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf',
+      })
+    })
+
+    it('returns null for /playlist without list param', () => {
+      expect(parse('https://youtube.com/playlist')).toBeNull()
+    })
+  })
+
+  describe('channel', () => {
+    it('parses /@{handle}', () => {
+      expect(parse('https://youtube.com/@mkbhd')).toEqual({
+        type: 'channel',
+        entities: { username: 'mkbhd' },
+        url: 'https://youtube.com/@mkbhd',
+      })
+    })
+
+    it('parses /channel/{id}', () => {
+      expect(parse('https://youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw')).toEqual({
+        type: 'channel',
+        entities: { channel_id: 'UCXuqSBlHAE6Xw-yeJA0Tunw' },
+        url: 'https://youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw',
+      })
+    })
+
+    it('parses /c/{name}', () => {
+      expect(parse('https://youtube.com/c/mkbhd')).toEqual({
+        type: 'channel',
+        entities: { username: 'mkbhd' },
+        url: 'https://youtube.com/@mkbhd',
+      })
+    })
+
+    it('parses /user/{name}', () => {
+      expect(parse('https://youtube.com/user/mkbhd')).toEqual({
+        type: 'channel',
+        entities: { username: 'mkbhd' },
+        url: 'https://youtube.com/@mkbhd',
+      })
+    })
+
+    it('rejects bare @ with no handle', () => {
+      expect(parse('https://youtube.com/@')).toBeNull()
+    })
+  })
+
+  describe('null cases', () => {
+    it('returns null for root path', () => {
+      expect(parse('https://youtube.com/')).toBeNull()
+    })
+
+    it('returns null for unrecognized paths', () => {
+      expect(parse('https://youtube.com/feed/subscriptions')).toBeNull()
+    })
+
+    it('returns null for youtu.be with multiple segments', () => {
+      expect(parse('https://youtu.be/abc/def')).toBeNull()
+    })
+  })
+})

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['test/**'],
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add a new TypeScript social media URL parser package with `parse`, `identify`, and `normalize` APIs
- implement platform parsers for Twitter/X, Instagram, TikTok, Reddit, GitHub, YouTube, Facebook, search engines, LinkedIn, Threads, Bluesky, Pinterest, Twitch, Telegram, Snapchat, Vimeo, and Dailymotion
- add URL cleaning/normalization utilities and exported platform parser modules
- add comprehensive Vitest coverage, including parser-specific suites, cross-platform edge-case invariants, and 100% coverage gating
- add project/tooling/release setup (`package.json`, TypeScript configs, oxlint, GitHub Actions CI + release workflow, README, LICENSE)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nikuscs/social-media-parser/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
